### PR TITLE
feat: 支持网易云音乐 163 key 的生成与匹配

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@
 - [EBU R128](https://github.com/jiixyj/libebur128) - EBU R128 音频等级标准实现库，用于计算 ReplayGain
 - [Foobar2000](https://www.foobar2000.org/SDK) - Foobar2000 SDK，提供了丰富的音频处理和元数据编辑功能
 - ~[Auxio - musikr](https://github.com/OxygenCobalt/Auxio/tree/dev/musikr) - Musikr 是一个高度主观设计（highly opinionated）且支持多线程的音乐加载器，用于支持 Auxio 的高级音乐功能~
+- [163KeyDecrypter](https://github.com/lycode404/163KeyDecrypter) - 163KeyDecrypter，解密网易云音乐下载歌曲文件的 163key 标签信息

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/BatchMatchConfig.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/BatchMatchConfig.kt
@@ -34,6 +34,7 @@ enum class BatchMatchField(
     TRACK_NUMBER(R.string.label_track_number),
     LYRICS(R.string.label_lyrics),
     COVER(R.string.label_cover),
+    NETEASE_163_KEY(R.string.label_netease_163_key, R.string.label_netease_163_key_summary),
     REPLAY_GAIN(R.string.label_replay_gain, R.string.label_replay_gain_summary)
 }
 object BatchMatchConfigDefaults {
@@ -47,6 +48,7 @@ object BatchMatchConfigDefaults {
             BatchMatchField.TRACK_NUMBER to BatchMatchMode.SUPPLEMENT,
             BatchMatchField.LYRICS to BatchMatchMode.SUPPLEMENT,
             BatchMatchField.COVER to BatchMatchMode.SUPPLEMENT,
+            BatchMatchField.NETEASE_163_KEY to BatchMatchMode.SUPPLEMENT,
             BatchMatchField.REPLAY_GAIN to BatchMatchMode.SUPPLEMENT
         ),
         concurrency = 3,

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
@@ -207,6 +207,7 @@ class SongRepositoryImpl(
                     trackerNumber = tag.trackNumber ?: song.trackerNumber,
                     album = tag.album ?: song.album,
                     genre = tag.genre ?: song.genre,
+                    comment = tag.comment ?: song.comment,
                     fileLastModified = newModifiedTime // 更新为当前时间
                 ).withSortKeysUpdated()
             }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchMatchViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchMatchViewModel.kt
@@ -296,6 +296,7 @@ class BatchMatchViewModel(
                 BatchMatchField.TRACK_NUMBER -> song.trackerNumber.isNullOrBlank()
                 BatchMatchField.LYRICS -> song.lyrics.isNullOrBlank()
                 BatchMatchField.COVER -> true
+                BatchMatchField.NETEASE_163_KEY -> song.comment.isNullOrBlank()
                 BatchMatchField.REPLAY_GAIN -> song.rawProperties?.contains("REPLAYGAIN_TRACK_GAIN") != true
             }
         }
@@ -341,6 +342,8 @@ class BatchMatchViewModel(
         }
 
         var bestMatch: ScoredSearchResult? = null
+        var bestNeteaseMatch: ScoredSearchResult? = null
+        val needsNetease163Key = matchConfig.fields.containsKey(BatchMatchField.NETEASE_163_KEY)
 
         for (query in queries) {
             val searchTasks = orderedSources.map { source ->
@@ -357,13 +360,24 @@ class BatchMatchViewModel(
 
             val allResults = searchTasks.awaitAll().flatten()
             val currentBest = allResults.maxByOrNull { it.score }
+            val currentBestNetease = allResults
+                .filter { it.result.source == Source.NE }
+                .maxByOrNull { it.score }
 
             if (currentBest != null) {
                 if (bestMatch == null || currentBest.score > bestMatch.score) {
                     bestMatch = currentBest
                 }
-                if (currentBest.score > 0.9) break
             }
+            if (currentBestNetease != null &&
+                (bestNeteaseMatch == null || currentBestNetease.score > bestNeteaseMatch.score)
+            ) {
+                bestNeteaseMatch = currentBestNetease
+            }
+            if (currentBest != null &&
+                currentBest.score > 0.9 &&
+                (!needsNetease163Key || bestNeteaseMatch != null)
+            ) break
         }
 
         val finalMatch = bestMatch ?: return@coroutineScope MatchResult(null, BatchMatchResult.FAILURE)
@@ -384,6 +398,18 @@ class BatchMatchViewModel(
             val newTrack = resolveValue(matchConfig, BatchMatchField.TRACK_NUMBER, song.trackerNumber, finalMatch.result.trackerNumber)
             val newGenre = resolveValue(matchConfig, BatchMatchField.GENRE, song.genre, null)
             val newLyricsResolved = resolveValue(matchConfig, BatchMatchField.LYRICS, song.lyrics, newLyrics)
+            val netease163Key = finalMatch.result.extras["netease_163_key"]
+                ?: bestNeteaseMatch
+                    ?.takeIf { it.score >= 0.35 }
+                    ?.result
+                    ?.extras
+                    ?.get("netease_163_key")
+            val newComment = resolveValue(
+                matchConfig,
+                BatchMatchField.NETEASE_163_KEY,
+                song.comment,
+                netease163Key
+            )
 
             val shouldUpdateCover = shouldUpdate(matchConfig, BatchMatchField.COVER, null)
             val picUrl = if (shouldUpdateCover) finalMatch.result.picUrl else null
@@ -415,6 +441,7 @@ class BatchMatchViewModel(
                 date = newDate,
                 trackNumber = newTrack,
                 lyrics = newLyricsResolved,
+                comment = newComment,
                 picUrl = picUrl,
                 replayGainTrackGain = replayGainData?.trackGain,
                 replayGainTrackPeak = replayGainData?.trackPeak,
@@ -426,7 +453,7 @@ class BatchMatchViewModel(
             // Check if tagDataToWrite is effectively empty (no fields to update)
             val isEffectivelyEmpty = newTitle == null && newArtist == null && newAlbum == null &&
                     newGenre == null && newDate == null && newTrack == null &&
-                    newLyricsResolved == null && picUrl == null &&
+                    newLyricsResolved == null && newComment == null && picUrl == null &&
                     replayGainData == null
 
             if (isEffectivelyEmpty) return@coroutineScope MatchResult(null, BatchMatchResult.SKIPPED)

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
@@ -222,6 +222,7 @@ class EditMetadataViewModel(
             val albumGain = pick("replaygain_album_gain", "rg_album_gain")
             val albumPeak = pick("replaygain_album_peak", "rg_album_peak")
             var refLoudness = pick("replaygain_reference_loudness", "r128_reference_loudness")
+            val netease163Key = pick("netease_163_key")
 
             if (refLoudness == null && trackGain != null) {
                 refLoudness = "-18 LUFS"
@@ -236,6 +237,7 @@ class EditMetadataViewModel(
                     date = result.date?.takeIf { it.isNotBlank() } ?: current.date,
                     trackNumber = result.trackerNumber?.takeIf { it.isNotBlank() }
                         ?: current.trackNumber,
+                    comment = netease163Key ?: current.comment,
                     picUrl = result.picUrl?.takeIf { it.isNotBlank() } ?: current.picUrl,
                     replayGainTrackGain = trackGain ?: current.replayGainTrackGain,
                     replayGainTrackPeak = trackPeak ?: current.replayGainTrackPeak,

--- a/lyrico-app/src/main/res/values-zh-rCN/strings.xml
+++ b/lyrico-app/src/main/res/values-zh-rCN/strings.xml
@@ -283,6 +283,8 @@
     <string name="label_lyricist">作词</string>
     <string name="label_comment">注释</string>
     <string name="label_lyrics">歌词</string>
+    <string name="label_netease_163_key">网易云 163 key</string>
+    <string name="label_netease_163_key_summary">写入网易云 163 key 到注释标签。仅网易云音乐源支持匹配该字段。</string>
     <string name="label_replay_gain">回放增益</string>
     <string name="label_replay_gain_summary">仅QQ源支持匹配该字段</string>
     <string name="group_replay_gain">ReplayGain</string>

--- a/lyrico-app/src/main/res/values/strings.xml
+++ b/lyrico-app/src/main/res/values/strings.xml
@@ -278,6 +278,8 @@
     <string name="label_lyricist">Lyricist</string>
     <string name="label_comment">Comment</string>
     <string name="label_lyrics">Lyrics</string>
+    <string name="label_netease_163_key">NetEase 163 key</string>
+    <string name="label_netease_163_key_summary">Writes the NetEase 163 key into the comment tag. Only NetEase Cloud Music source supports matching this field.</string>
     <string name="label_replay_gain">ReplayGain</string>
     <string name="label_replay_gain_summary">Only QQ Music source supports matching this field</string>
     <string name="group_replay_gain">ReplayGain</string>

--- a/lyrico-lyrics/src/main/java/com/lonx/lyrics/source/ne/NeApi.kt
+++ b/lyrico-lyrics/src/main/java/com/lonx/lyrics/source/ne/NeApi.kt
@@ -40,14 +40,33 @@ data class NeSongData(
     @SerialName("al") val album: NeAlbum,
     @SerialName("dt") val duration: Long,
     @SerialName("publishTime") val publishTime: Long? = null,
-    @SerialName("no") val trackerNumber: String = ""
+    @SerialName("no") val trackerNumber: String = "",
+    @SerialName("h") val highQuality: NeSongQuality? = null,
+    @SerialName("m") val mediumQuality: NeSongQuality? = null,
+    @SerialName("l") val lowQuality: NeSongQuality? = null,
+    @SerialName("sq") val losslessQuality: NeSongQuality? = null,
+    @SerialName("mv") val mvId: Long = 0
 )
 
 @Serializable
-data class NeArtist(val name: String)
+data class NeArtist(
+    @SerialName("id") val id: Long = 0,
+    @SerialName("name") val name: String
+)
 
 @Serializable
-data class NeAlbum(val name: String, val picUrl: String = "")
+data class NeSongQuality(
+    @SerialName("br") val bitrate: Int = 0
+)
+
+@Serializable
+data class NeAlbum(
+    @SerialName("id") val id: Long = 0,
+    @SerialName("name") val name: String,
+    @SerialName("picUrl") val picUrl: String = "",
+    @SerialName("pic") val pic: Long? = null,
+    @SerialName("pic_str") val picStr: String? = null
+)
 
 @Serializable
 data class NeLyricResponse(

--- a/lyrico-lyrics/src/main/java/com/lonx/lyrics/source/ne/NeSource.kt
+++ b/lyrico-lyrics/src/main/java/com/lonx/lyrics/source/ne/NeSource.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -25,6 +26,8 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
 import kotlin.random.Random
 import androidx.core.content.edit
 import kotlinx.serialization.json.jsonPrimitive
@@ -338,7 +341,8 @@ class NeSource(
                     source = Source.NE,
                     date = song.publishTime?.let { formatMillisToDate(it) } ?: "",
                     trackerNumber = song.trackerNumber,
-                    picUrl = song.album.picUrl
+                    picUrl = song.album.picUrl,
+                    extras = buildNeteaseExtras(song)
                 )
             } ?: emptyList()
 
@@ -385,7 +389,8 @@ class NeSource(
                     source = Source.NE,
                     date = song.publishTime?.let { formatMillisToDate(it) } ?: "",
                     trackerNumber = song.trackerNumber,
-                    picUrl = picUrl
+                    picUrl = picUrl,
+                    extras = buildNeteaseExtras(song)
                 )
             } ?: emptyList()
 
@@ -449,5 +454,55 @@ class NeSource(
             .atZone(ZoneId.systemDefault())
             .toLocalDate()
             .format(formatter)
+    }
+
+    private fun buildNeteaseExtras(song: NeSongData): Map<String, String> {
+        val key = buildNetease163Key(song) ?: return emptyMap()
+        return mapOf("netease_163_key" to key)
+    }
+
+    private fun buildNetease163Key(song: NeSongData): String? {
+        return try {
+            val bitrate = listOfNotNull(
+                song.losslessQuality?.bitrate,
+                song.highQuality?.bitrate,
+                song.mediumQuality?.bitrate,
+                song.lowQuality?.bitrate
+            ).firstOrNull { it > 0 } ?: 0
+            val albumPicDocId = song.album.picStr?.toLongOrNull() ?: song.album.pic ?: 0L
+            val metadata = buildJsonObject {
+                put("musicName", song.name)
+                put("musicId", song.id)
+                put(
+                    "artist",
+                    JsonArray(song.artists.map { artist ->
+                        JsonArray(listOf(JsonPrimitive(artist.name), JsonPrimitive(artist.id)))
+                    })
+                )
+                put("album", song.album.name)
+                put("albumId", song.album.id)
+                put("albumPic", song.album.picUrl)
+                put("albumPicDocId", albumPicDocId)
+                put("bitrate", bitrate)
+                put("duration", song.duration)
+                put("mvId", song.mvId)
+                put("alias", JsonArray(song.alia.orEmpty().map { JsonPrimitive(it) }))
+                put("transNames", JsonArray(emptyList()))
+                put("format", if (bitrate > 320000) "flac" else "mp3")
+                put("flag", 0)
+                put("gain", 0.0)
+            }
+
+            val metadataJson = json.encodeToString(JsonObject.serializer(), metadata)
+                .replace("/", "\\/")
+            val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+            val keySpec = SecretKeySpec("#14ljk_!\\]&0U<'(".toByteArray(Charsets.UTF_8), "AES")
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec)
+            val encrypted = cipher.doFinal("music:$metadataJson".toByteArray(Charsets.UTF_8))
+            "163 key(Don't modify):" + Base64.encodeToString(encrypted, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            Log.e("NeSource", "Build 163 key failed", e)
+            null
+        }
     }
 }


### PR DESCRIPTION
- 在 `NeSource` 中实现网易云 163 key 的生成逻辑，支持 AES 加密及元数据构建
- 扩展 `NeApi` 数据模型以包含比特率、音质、专辑 ID 及图片标识等详细信息
- 在批量匹配流程中新增 `NETEASE_163_KEY` 匹配项，支持将其写入注释标签
- 优化 `BatchMatchViewModel` 搜索逻辑，确保在需要 163 key 时优先匹配网易云数据源
- 在元数据编辑界面及批量匹配配置中添加对 163 key 字段的支持
- 在 `README` 中新增 `163KeyDecrypter` 参考项目

批量获取
<img width="886" height="1920" alt="ae7e6da77e3f5825ecf1476108d6e212" src="https://github.com/user-attachments/assets/87e15690-7dcc-4346-93ce-be2abfe77fe6" />
单曲获取（需要歌词来源选择网易云）
<img width="886" height="1920" alt="328b6cdc81f40e7433b1440def9e8837_720" src="https://github.com/user-attachments/assets/ae9ff351-552c-4914-a545-3a29d7d3a9ae" />
效果如下：
<img width="886" height="1920" alt="b4ced74e2889bc9d0cafd90ef9353e1e" src="https://github.com/user-attachments/assets/51c95487-8bfb-42e5-a144-d9bb131191e6" />
<img width="886" height="1920" alt="88fbf53f92a33f58be54d25a17feb1d2_720" src="https://github.com/user-attachments/assets/41979568-296f-4541-ac69-bc0c2f44e075" />
