### PR TITLE
feat: 实现自定义标签管理功能

### DIFF
--- a/lyrico-app/schemas/com.lonx.lyrico.data.LyricoDatabase/14.json
+++ b/lyrico-app/schemas/com.lonx.lyrico.data.LyricoDatabase/14.json
@@ -1,0 +1,1214 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "24049ee5fc2312cf84d244a22878a602",
+    "entities": [
+      {
+        "tableName": "songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `folderId` INTEGER NOT NULL, `mediaId` INTEGER NOT NULL, `source` TEXT NOT NULL DEFAULT 'MEDIA_STORE', `filePath` TEXT NOT NULL, `fileName` TEXT NOT NULL, `fileSize` INTEGER NOT NULL DEFAULT 0, `fileExtension` TEXT, `title` TEXT, `artist` TEXT, `albumArtist` TEXT, `discNumber` INTEGER, `composer` TEXT, `lyricist` TEXT, `comment` TEXT, `album` TEXT, `genre` TEXT, `language` TEXT DEFAULT NULL, `trackerNumber` TEXT, `date` TEXT, `lyrics` TEXT, `copyright` TEXT DEFAULT NULL, `rating` INTEGER DEFAULT NULL, `replayGainTrackGain` TEXT DEFAULT NULL, `replayGainTrackPeak` TEXT DEFAULT NULL, `replayGainAlbumGain` TEXT DEFAULT NULL, `replayGainAlbumPeak` TEXT DEFAULT NULL, `replayGainReferenceLoudness` TEXT DEFAULT NULL, `durationMilliseconds` INTEGER NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER NOT NULL, `channels` INTEGER NOT NULL, `rawProperties` TEXT, `fileLastModified` INTEGER NOT NULL, `fileAdded` INTEGER NOT NULL DEFAULT 0, `dbUpdateTime` INTEGER NOT NULL, `titleGroupKey` TEXT NOT NULL, `titleSortKey` TEXT NOT NULL, `artistGroupKey` TEXT NOT NULL, `artistSortKey` TEXT NOT NULL, `uri` TEXT NOT NULL DEFAULT '0', FOREIGN KEY(`folderId`) REFERENCES `folders`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'MEDIA_STORE'"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fileExtension",
+            "columnName": "fileExtension",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "albumArtist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "composer",
+            "columnName": "composer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricist",
+            "columnName": "lyricist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "trackerNumber",
+            "columnName": "trackerNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "copyright",
+            "columnName": "copyright",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "replayGainTrackGain",
+            "columnName": "replayGainTrackGain",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "replayGainTrackPeak",
+            "columnName": "replayGainTrackPeak",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "replayGainAlbumGain",
+            "columnName": "replayGainAlbumGain",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "replayGainAlbumPeak",
+            "columnName": "replayGainAlbumPeak",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "replayGainReferenceLoudness",
+            "columnName": "replayGainReferenceLoudness",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "durationMilliseconds",
+            "columnName": "durationMilliseconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawProperties",
+            "columnName": "rawProperties",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileLastModified",
+            "columnName": "fileLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileAdded",
+            "columnName": "fileAdded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dbUpdateTime",
+            "columnName": "dbUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleGroupKey",
+            "columnName": "titleGroupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleSortKey",
+            "columnName": "titleSortKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistGroupKey",
+            "columnName": "artistGroupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistSortKey",
+            "columnName": "artistSortKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_songs_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_songs_uri` ON `${TABLE_NAME}` (`uri`)"
+          },
+          {
+            "name": "index_songs_filePath",
+            "unique": false,
+            "columnNames": [
+              "filePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_filePath` ON `${TABLE_NAME}` (`filePath`)"
+          },
+          {
+            "name": "index_songs_folderId",
+            "unique": false,
+            "columnNames": [
+              "folderId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_folderId` ON `${TABLE_NAME}` (`folderId`)"
+          },
+          {
+            "name": "index_songs_titleGroupKey_titleSortKey",
+            "unique": false,
+            "columnNames": [
+              "titleGroupKey",
+              "titleSortKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_titleGroupKey_titleSortKey` ON `${TABLE_NAME}` (`titleGroupKey`, `titleSortKey`)"
+          },
+          {
+            "name": "index_songs_artistGroupKey_artistSortKey",
+            "unique": false,
+            "columnNames": [
+              "artistGroupKey",
+              "artistSortKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artistGroupKey_artistSortKey` ON `${TABLE_NAME}` (`artistGroupKey`, `artistSortKey`)"
+          },
+          {
+            "name": "index_songs_fileLastModified",
+            "unique": false,
+            "columnNames": [
+              "fileLastModified"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_fileLastModified` ON `${TABLE_NAME}` (`fileLastModified`)"
+          },
+          {
+            "name": "index_songs_fileAdded",
+            "unique": false,
+            "columnNames": [
+              "fileAdded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_fileAdded` ON `${TABLE_NAME}` (`fileAdded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "folders",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "folderId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `treeUri` TEXT, `songCount` INTEGER NOT NULL, `isIgnored` INTEGER NOT NULL, `addedBySaf` INTEGER NOT NULL, `lastScanned` INTEGER NOT NULL, `dbUpdateTime` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "isIgnored",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedBySaf",
+            "columnName": "addedBySaf",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastScanned",
+            "columnName": "lastScanned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dbUpdateTime",
+            "columnName": "dbUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_folders_path",
+            "unique": true,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_folders_path` ON `${TABLE_NAME}` (`path`)"
+          },
+          {
+            "name": "index_folders_isIgnored",
+            "unique": false,
+            "columnNames": [
+              "isIgnored"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_folders_isIgnored` ON `${TABLE_NAME}` (`isIgnored`)"
+          },
+          {
+            "name": "index_folders_songCount",
+            "unique": false,
+            "columnNames": [
+              "songCount"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_folders_songCount` ON `${TABLE_NAME}` (`songCount`)"
+          },
+          {
+            "name": "index_folders_addedBySaf",
+            "unique": false,
+            "columnNames": [
+              "addedBySaf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_folders_addedBySaf` ON `${TABLE_NAME}` (`addedBySaf`)"
+          }
+        ]
+      },
+      {
+        "tableName": "batch_tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`taskId` TEXT NOT NULL, `type` TEXT NOT NULL, `status` TEXT NOT NULL, `total` INTEGER NOT NULL, `current` INTEGER NOT NULL, `successCount` INTEGER NOT NULL, `failureCount` INTEGER NOT NULL, `skippedCount` INTEGER NOT NULL, `currentFile` TEXT, `configJson` TEXT, `workId` TEXT, `startedAt` INTEGER, `finishedAt` INTEGER, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `errorMessage` TEXT, PRIMARY KEY(`taskId`))",
+        "fields": [
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "current",
+            "columnName": "current",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successCount",
+            "columnName": "successCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skippedCount",
+            "columnName": "skippedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentFile",
+            "columnName": "currentFile",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "workId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "taskId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_batch_tasks_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_batch_tasks_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "batch_task_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `taskId` TEXT NOT NULL, `mediaId` INTEGER NOT NULL, `songUri` TEXT NOT NULL, `filePath` TEXT, `fileName` TEXT NOT NULL, `status` TEXT NOT NULL, `progress` REAL, `resultJson` TEXT, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taskId",
+            "columnName": "taskId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "mediaId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songUri",
+            "columnName": "songUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "resultJson",
+            "columnName": "resultJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_batch_task_items_taskId",
+            "unique": false,
+            "columnNames": [
+              "taskId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_batch_task_items_taskId` ON `${TABLE_NAME}` (`taskId`)"
+          },
+          {
+            "name": "index_batch_task_items_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_batch_task_items_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "app_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` INTEGER NOT NULL, `level` TEXT NOT NULL, `type` TEXT NOT NULL, `tag` TEXT NOT NULL, `message` TEXT NOT NULL, `detail` TEXT, `relatedId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detail",
+            "columnName": "detail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "relatedId",
+            "columnName": "relatedId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_app_logs_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_app_logs_level",
+            "unique": false,
+            "columnNames": [
+              "level"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_level` ON `${TABLE_NAME}` (`level`)"
+          },
+          {
+            "name": "index_app_logs_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_type` ON `${TABLE_NAME}` (`type`)"
+          },
+          {
+            "name": "index_app_logs_relatedId",
+            "unique": false,
+            "columnNames": [
+              "relatedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_app_logs_relatedId` ON `${TABLE_NAME}` (`relatedId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `normalizedName` TEXT NOT NULL, `groupKey` TEXT NOT NULL, `sortKey` TEXT NOT NULL, `songCount` INTEGER NOT NULL, `albumCount` INTEGER NOT NULL, `coverSongUri` TEXT, `coverSongLastModified` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalizedName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortKey",
+            "columnName": "sortKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumCount",
+            "columnName": "albumCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverSongUri",
+            "columnName": "coverSongUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverSongLastModified",
+            "columnName": "coverSongLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artists_normalizedName",
+            "unique": true,
+            "columnNames": [
+              "normalizedName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_artists_normalizedName` ON `${TABLE_NAME}` (`normalizedName`)"
+          },
+          {
+            "name": "index_artists_groupKey_sortKey",
+            "unique": false,
+            "columnNames": [
+              "groupKey",
+              "sortKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artists_groupKey_sortKey` ON `${TABLE_NAME}` (`groupKey`, `sortKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistId` INTEGER NOT NULL, `songId` INTEGER NOT NULL, PRIMARY KEY(`artistId`, `songId`), FOREIGN KEY(`artistId`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `songs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artist_song_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_song_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          },
+          {
+            "name": "index_artist_song_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_song_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "artists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "songs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `albumArtist` TEXT, `normalizedKey` TEXT NOT NULL, `groupKey` TEXT NOT NULL, `sortKey` TEXT NOT NULL, `songCount` INTEGER NOT NULL, `coverSongUri` TEXT, `coverSongLastModified` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "albumArtist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "normalizedKey",
+            "columnName": "normalizedKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupKey",
+            "columnName": "groupKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortKey",
+            "columnName": "sortKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverSongUri",
+            "columnName": "coverSongUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverSongLastModified",
+            "columnName": "coverSongLastModified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_albums_normalizedKey",
+            "unique": true,
+            "columnNames": [
+              "normalizedKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_albums_normalizedKey` ON `${TABLE_NAME}` (`normalizedKey`)"
+          },
+          {
+            "name": "index_albums_groupKey_sortKey",
+            "unique": false,
+            "columnNames": [
+              "groupKey",
+              "sortKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_groupKey_sortKey` ON `${TABLE_NAME}` (`groupKey`, `sortKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "album_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` INTEGER NOT NULL, `songId` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `songId`), FOREIGN KEY(`albumId`) REFERENCES `albums`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `songs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_song_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_song_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "albums",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "songs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_plugins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `versionCode` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `apiVersion` INTEGER NOT NULL, `pluginDir` TEXT NOT NULL, `entryFile` TEXT NOT NULL, `includeDirsJson` TEXT NOT NULL, `iconPath` TEXT, `enabled` INTEGER NOT NULL, `sortOrder` INTEGER NOT NULL, `installedAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "versionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiVersion",
+            "columnName": "apiVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pluginDir",
+            "columnName": "pluginDir",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryFile",
+            "columnName": "entryFile",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeDirsJson",
+            "columnName": "includeDirsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconPath",
+            "columnName": "iconPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_custom_tag_keys",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songUri` TEXT NOT NULL, `key` TEXT NOT NULL, PRIMARY KEY(`songUri`, `key`))",
+        "fields": [
+          {
+            "fieldPath": "songUri",
+            "columnName": "songUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songUri",
+            "key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_custom_tag_keys_key",
+            "unique": false,
+            "columnNames": [
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_custom_tag_keys_key` ON `${TABLE_NAME}` (`key`)"
+          },
+          {
+            "name": "index_song_custom_tag_keys_songUri",
+            "unique": false,
+            "columnNames": [
+              "songUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_custom_tag_keys_songUri` ON `${TABLE_NAME}` (`songUri`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '24049ee5fc2312cf84d244a22878a602')"
+    ]
+  }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/LyricoDatabase.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/LyricoDatabase.kt
@@ -10,6 +10,7 @@ import com.lonx.lyrico.data.model.dao.BatchTaskDao
 import com.lonx.lyrico.data.model.dao.FolderDao
 import com.lonx.lyrico.data.model.dao.LibraryIndexDao
 import com.lonx.lyrico.data.model.dao.SongDao
+import com.lonx.lyrico.data.model.dao.SongCustomTagKeyDao
 import com.lonx.lyrico.data.model.dao.SourcePluginDao
 import com.lonx.lyrico.data.model.entity.AlbumEntity
 import com.lonx.lyrico.data.model.entity.AlbumSongCrossRef
@@ -20,6 +21,7 @@ import com.lonx.lyrico.data.model.entity.BatchTaskEntity
 import com.lonx.lyrico.data.model.entity.BatchTaskItemEntity
 import com.lonx.lyrico.data.model.entity.FolderEntity
 import com.lonx.lyrico.data.model.entity.SongEntity
+import com.lonx.lyrico.data.model.entity.SongCustomTagKeyEntity
 import com.lonx.lyrico.data.model.entity.SourcePluginEntity
 
 @Database(
@@ -33,9 +35,10 @@ import com.lonx.lyrico.data.model.entity.SourcePluginEntity
         ArtistSongCrossRef::class,
         AlbumEntity::class,
         AlbumSongCrossRef::class,
-        SourcePluginEntity::class
+        SourcePluginEntity::class,
+        SongCustomTagKeyEntity::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -53,6 +56,7 @@ abstract class LyricoDatabase : RoomDatabase() {
     abstract fun appLogDao(): AppLogDao
     abstract fun libraryIndexDao(): LibraryIndexDao
     abstract fun sourcePluginDao(): SourcePluginDao
+    abstract fun songCustomTagKeyDao(): SongCustomTagKeyDao
 
     companion object {
         val MIGRATION_9_10 = object : Migration(9, 10) {
@@ -278,6 +282,32 @@ abstract class LyricoDatabase : RoomDatabase() {
         val MIGRATION_12_13 = object : Migration(12, 13) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE source_plugins ADD COLUMN includeDirsJson TEXT NOT NULL DEFAULT '[]'")
+            }
+        }
+
+        val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS song_custom_tag_keys (
+                        songUri TEXT NOT NULL,
+                        `key` TEXT NOT NULL,
+                        PRIMARY KEY(songUri, `key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS index_song_custom_tag_keys_key
+                    ON song_custom_tag_keys(`key`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS index_song_custom_tag_keys_songUri
+                    ON song_custom_tag_keys(songUri)
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/editfield/EditFieldRegistry.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/editfield/EditFieldRegistry.kt
@@ -8,7 +8,6 @@ object EditFieldRegistry {
     const val GROUP_TRACK_DETAILS = "track_details"
     const val GROUP_CREDITS_OTHER = "credits_other"
     const val GROUP_REPLAY_GAIN = "replay_gain"
-    const val GROUP_CUSTOM_TAGS = "custom_tags"
     const val GROUP_LYRICS = "lyrics"
     const val GROUP_COVER = "cover"
 
@@ -36,12 +35,6 @@ object EditFieldRegistry {
             titleRes = R.string.group_replay_gain,
             defaultVisible = true,
             order = 40,
-        ),
-        EditFieldGroupDefinition(
-            code = GROUP_CUSTOM_TAGS,
-            titleRes = R.string.group_custom_tags,
-            defaultVisible = true,
-            order = 45,
         ),
         EditFieldGroupDefinition(
             code = GROUP_LYRICS,
@@ -203,15 +196,6 @@ object EditFieldRegistry {
             titleRes = R.string.label_replaygain_reference_loudness,
             defaultVisible = true,
             order = 50,
-            scope = EditFieldScope.Both,
-        ),
-
-        EditFieldDefinition(
-            code = "custom_tags.custom_tags",
-            groupCode = GROUP_CUSTOM_TAGS,
-            titleRes = R.string.label_custom_tag,
-            defaultVisible = true,
-            order = 10,
             scope = EditFieldScope.Both,
         ),
 

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/CustomTagKeyCount.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/CustomTagKeyCount.kt
@@ -1,0 +1,6 @@
+package com.lonx.lyrico.data.model.dao
+
+data class CustomTagKeyCount(
+    val key: String,
+    val songCount: Int,
+)

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/SongCustomTagKeyDao.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/SongCustomTagKeyDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import com.lonx.lyrico.data.model.entity.SongCustomTagKeyEntity
 import kotlinx.coroutines.flow.Flow
+import java.util.Locale
 
 @Dao
 interface SongCustomTagKeyDao {
@@ -50,6 +51,7 @@ interface SongCustomTagKeyDao {
         val items = keys
             .map { it.trim() }
             .filter { it.isNotBlank() }
+            .map { it.uppercase(Locale.ROOT) }
             .distinct()
             .map { key ->
                 SongCustomTagKeyEntity(

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/SongCustomTagKeyDao.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/dao/SongCustomTagKeyDao.kt
@@ -1,0 +1,65 @@
+package com.lonx.lyrico.data.model.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.lonx.lyrico.data.model.entity.SongCustomTagKeyEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SongCustomTagKeyDao {
+
+    @Query(
+        """
+        SELECT `key`, COUNT(*) AS songCount
+        FROM song_custom_tag_keys
+        GROUP BY `key`
+        ORDER BY songCount DESC, `key` COLLATE NOCASE ASC
+        """
+    )
+    fun observeCustomTagKeyCounts(): Flow<List<CustomTagKeyCount>>
+
+    @Query(
+        """
+        SELECT songUri
+        FROM song_custom_tag_keys
+        WHERE `key` = :key
+        ORDER BY songUri ASC
+        """
+    )
+    suspend fun getSongUrisByKey(key: String): List<String>
+
+    @Query("DELETE FROM song_custom_tag_keys WHERE songUri = :songUri")
+    suspend fun deleteForSong(songUri: String)
+
+    @Query("DELETE FROM song_custom_tag_keys WHERE songUri IN (:songUris)")
+    suspend fun deleteForSongs(songUris: List<String>)
+
+    @Query("DELETE FROM song_custom_tag_keys")
+    suspend fun clearAll()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<SongCustomTagKeyEntity>)
+
+    @Transaction
+    suspend fun replaceForSong(songUri: String, keys: List<String>) {
+        deleteForSong(songUri)
+
+        val items = keys
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .map { key ->
+                SongCustomTagKeyEntity(
+                    songUri = songUri,
+                    key = key,
+                )
+            }
+
+        if (items.isNotEmpty()) {
+            insertAll(items)
+        }
+    }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/entity/SongCustomTagKeyEntity.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/entity/SongCustomTagKeyEntity.kt
@@ -1,0 +1,17 @@
+package com.lonx.lyrico.data.model.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "song_custom_tag_keys",
+    primaryKeys = ["songUri", "key"],
+    indices = [
+        Index(value = ["key"]),
+        Index(value = ["songUri"]),
+    ],
+)
+data class SongCustomTagKeyEntity(
+    val songUri: String,
+    val key: String,
+)

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagKeyRepository.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagKeyRepository.kt
@@ -1,0 +1,38 @@
+package com.lonx.lyrico.data.repository
+
+import com.lonx.audiotag.model.CustomTagField
+import com.lonx.lyrico.data.model.dao.CustomTagKeyCount
+import com.lonx.lyrico.data.model.dao.SongCustomTagKeyDao
+import kotlinx.coroutines.flow.Flow
+
+class CustomTagKeyRepository(
+    private val dao: SongCustomTagKeyDao,
+) {
+
+    fun observeKeyCounts(): Flow<List<CustomTagKeyCount>> {
+        return dao.observeCustomTagKeyCounts()
+    }
+
+    suspend fun replaceForSong(
+        songUri: String,
+        customFields: List<CustomTagField>,
+    ) {
+        dao.replaceForSong(
+            songUri = songUri,
+            keys = customFields.map { it.key },
+        )
+    }
+
+    suspend fun removeSongs(songUris: List<String>) {
+        if (songUris.isEmpty()) return
+        dao.deleteForSongs(songUris)
+    }
+
+    suspend fun clearAll() {
+        dao.clearAll()
+    }
+
+    suspend fun getSongUrisByKey(key: String): List<String> {
+        return dao.getSongUrisByKey(key)
+    }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagKeyRepository.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagKeyRepository.kt
@@ -4,6 +4,7 @@ import com.lonx.audiotag.model.CustomTagField
 import com.lonx.lyrico.data.model.dao.CustomTagKeyCount
 import com.lonx.lyrico.data.model.dao.SongCustomTagKeyDao
 import kotlinx.coroutines.flow.Flow
+import java.util.Locale
 
 class CustomTagKeyRepository(
     private val dao: SongCustomTagKeyDao,
@@ -19,7 +20,7 @@ class CustomTagKeyRepository(
     ) {
         dao.replaceForSong(
             songUri = songUri,
-            keys = customFields.map { it.key },
+            keys = customFields.mapNotNull { normalizeCustomTagKey(it.key) },
         )
     }
 
@@ -33,6 +34,16 @@ class CustomTagKeyRepository(
     }
 
     suspend fun getSongUrisByKey(key: String): List<String> {
-        return dao.getSongUrisByKey(key)
+        return dao.getSongUrisByKey(normalizeCustomTagKey(key) ?: return emptyList())
+    }
+
+    private fun normalizeCustomTagKey(input: String): String? {
+        val key = input.trim()
+        return when {
+            key.isBlank() -> null
+            key.length > 64 -> null
+            key.any { it == '\n' || it == '\r' } -> null
+            else -> key.uppercase(Locale.ROOT)
+        }
     }
 }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagSettingsRepository.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagSettingsRepository.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import java.util.Locale
 
 @Serializable
 data class CustomTagSettings(
@@ -52,6 +53,8 @@ class CustomTagSettingsRepository(
     }
 
     suspend fun removeVisibleKey(key: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
         context.settingsDataStore.edit { preferences ->
             val current = preferences[CUSTOM_TAG_SETTINGS]
                 ?.let { decodeSettings(it) }
@@ -61,7 +64,7 @@ class CustomTagSettingsRepository(
             preferences[CUSTOM_TAG_SETTINGS] =
                 encodeSettings(
                     current.copy(
-                        visibleKeys = current.visibleKeys - key
+                        visibleKeys = current.visibleKeys - normalizedKey
                     )
                 )
         }
@@ -112,7 +115,7 @@ class CustomTagSettingsRepository(
             key.isBlank() -> null
             key.length > 64 -> null
             key.any { it == '\n' || it == '\r' } -> null
-            else -> key
+            else -> key.uppercase(Locale.ROOT)
         }
     }
 

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagSettingsRepository.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/CustomTagSettingsRepository.kt
@@ -1,0 +1,123 @@
+package com.lonx.lyrico.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class CustomTagSettings(
+    val visibleKeys: List<String> = emptyList(),
+)
+
+class CustomTagSettingsRepository(
+    private val context: Context,
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    },
+) {
+
+    val settingsFlow: Flow<CustomTagSettings> =
+        context.settingsDataStore.data.map { preferences ->
+            val raw = preferences[CUSTOM_TAG_SETTINGS]
+            raw
+                ?.let { decodeSettings(it) }
+                ?.sanitize()
+                ?: CustomTagSettings()
+        }
+
+    suspend fun addVisibleKey(input: String) {
+        val key = normalizeCustomTagKey(input)
+            ?: throw IllegalArgumentException("Invalid custom tag key: $input")
+
+        context.settingsDataStore.edit { preferences ->
+            val current = preferences[CUSTOM_TAG_SETTINGS]
+                ?.let { decodeSettings(it) }
+                ?.sanitize()
+                ?: CustomTagSettings()
+
+            val nextKeys = if (key in current.visibleKeys) {
+                current.visibleKeys
+            } else {
+                current.visibleKeys + key
+            }
+
+            preferences[CUSTOM_TAG_SETTINGS] =
+                encodeSettings(current.copy(visibleKeys = nextKeys))
+        }
+    }
+
+    suspend fun removeVisibleKey(key: String) {
+        context.settingsDataStore.edit { preferences ->
+            val current = preferences[CUSTOM_TAG_SETTINGS]
+                ?.let { decodeSettings(it) }
+                ?.sanitize()
+                ?: CustomTagSettings()
+
+            preferences[CUSTOM_TAG_SETTINGS] =
+                encodeSettings(
+                    current.copy(
+                        visibleKeys = current.visibleKeys - key
+                    )
+                )
+        }
+    }
+
+    suspend fun setVisibleKeys(keys: List<String>) {
+        context.settingsDataStore.edit { preferences ->
+            preferences[CUSTOM_TAG_SETTINGS] =
+                encodeSettings(
+                    CustomTagSettings(
+                        visibleKeys = keys.sanitizeCustomTagKeys()
+                    )
+                )
+        }
+    }
+
+    suspend fun reset() {
+        context.settingsDataStore.edit { preferences ->
+            preferences.remove(CUSTOM_TAG_SETTINGS)
+        }
+    }
+
+    private fun decodeSettings(raw: String): CustomTagSettings {
+        return runCatching {
+            json.decodeFromString<CustomTagSettings>(raw)
+        }.getOrDefault(CustomTagSettings())
+    }
+
+    private fun encodeSettings(settings: CustomTagSettings): String {
+        return json.encodeToString(settings.sanitize())
+    }
+
+    private fun CustomTagSettings.sanitize(): CustomTagSettings {
+        return copy(
+            visibleKeys = visibleKeys.sanitizeCustomTagKeys()
+        )
+    }
+
+    private fun List<String>.sanitizeCustomTagKeys(): List<String> {
+        return mapNotNull { normalizeCustomTagKey(it) }
+            .distinct()
+    }
+
+    private fun normalizeCustomTagKey(input: String): String? {
+        val key = input.trim()
+
+        return when {
+            key.isBlank() -> null
+            key.length > 64 -> null
+            key.any { it == '\n' || it == '\r' } -> null
+            else -> key
+        }
+    }
+
+    companion object {
+        private val CUSTOM_TAG_SETTINGS =
+            stringPreferencesKey("custom_tag_settings")
+    }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
@@ -744,9 +744,15 @@ class SongRepositoryImpl(
                 fileLastModified = lastModified
             ).withSortKeysUpdated()
 
+            val savedCustomFields = runCatching {
+                readAudioTagData(contentUri).customFields
+            }.getOrNull()
+
             database.withTransaction {
                 songDao.update(updatedSong)
-                customTagKeyRepository.replaceForSong(contentUri, audioTagData.customFields)
+                if (savedCustomFields != null) {
+                    customTagKeyRepository.replaceForSong(contentUri, savedCustomFields)
+                }
                 libraryIndexRepository.reindexSongInTransaction(updatedSong)
             }
 
@@ -1214,6 +1220,12 @@ class SongRepositoryImpl(
                 } else if (star == 0) {
                     updateTagIfPresent("POPM", "", listOf("RATING", "RATE"))
                 }
+            }
+
+            audioTagData.customFields.forEach { field ->
+                val key = field.key.trim().uppercase(Locale.ROOT)
+                if (key.isEmpty() || AudioTagKeys.isReserved(key)) return@forEach
+                updates[key] = field.value.trim()
             }
 
             if (updates.isNotEmpty()) {

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
+import java.util.Locale
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -1136,7 +1137,7 @@ class SongRepositoryImpl(
                 }
 
             audioTagData.customFields.forEach { field ->
-                val key = field.key.trim()
+                val key = field.key.trim().uppercase(Locale.ROOT)
                 if (key.isEmpty() || AudioTagKeys.isReserved(key)) return@forEach
                 updates[key] = field.value.trim()
             }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/repository/SongRepositoryImpl.kt
@@ -16,6 +16,7 @@ import androidx.sqlite.db.SimpleSQLiteQuery
 import com.lonx.audiotag.model.AudioPicture
 import com.lonx.audiotag.model.AudioTagData
 import com.lonx.audiotag.model.AudioTagKeys
+import com.lonx.audiotag.model.CustomTagField
 import com.lonx.audiotag.rw.AudioTagReader
 import com.lonx.audiotag.rw.AudioTagWriter
 import com.lonx.lyrico.data.LyricoDatabase
@@ -53,7 +54,8 @@ class SongRepositoryImpl(
     private val settingsRepository: SettingsRepository,
     private val okHttpClient: OkHttpClient,
     private val appLogRepository: AppLogRepository,
-    private val libraryIndexRepository: LibraryIndexRepository
+    private val libraryIndexRepository: LibraryIndexRepository,
+    private val customTagKeyRepository: CustomTagKeyRepository
 ) : SongRepository {
 
     private val songDao = database.songDao()
@@ -110,6 +112,7 @@ class SongRepositoryImpl(
                 DeleteFileResult.AlreadyMissing -> {
                     database.withTransaction {
                         songDao.deleteByUri(song.uri)
+                        customTagKeyRepository.removeSongs(listOf(song.uri))
                         folderDao.refreshSongCount(song.folderId)
                         folderDao.performPostScanCleanup()
                     }
@@ -149,12 +152,13 @@ class SongRepositoryImpl(
             if (dbSongsToDelete.isEmpty()) return@withContext
 
             database.withTransaction {
-                dbSongsToDelete
-                    .map { it.uri }
-                    .chunked(BATCH_SIZE)
-                    .forEach { chunk ->
-                        songDao.deleteByUris(chunk)
-                    }
+                        dbSongsToDelete
+                            .map { it.uri }
+                            .chunked(BATCH_SIZE)
+                            .forEach { chunk ->
+                                songDao.deleteByUris(chunk)
+                                customTagKeyRepository.removeSongs(chunk)
+                            }
 
                 impactedFolderIds.forEach { folderId ->
                     folderDao.refreshSongCount(folderId)
@@ -370,7 +374,7 @@ class SongRepositoryImpl(
                     val impactedFolderIds = mutableSetOf<Long>()
                     val itemFailures = mutableListOf<String>()
 
-                    val songsToUpsert = mutableListOf<SongEntity>()
+                    val songsToUpsert = mutableListOf<ScannedSongMetadata>()
 
                     val safFolders = if (folderIds == null) {
                         folderDao.getSafFolders()
@@ -420,14 +424,14 @@ class SongRepositoryImpl(
                                     )
                                     impactedFolderIds.add(folderId)
 
-                                    val entity = extractSongMetadata(
+                                    val metadata = extractSongMetadata(
                                         songFile = deviceSong,
                                         folderId = folderId,
                                         existingId = dbInfo?.id ?: 0L,
                                         source = "SAF"
                                     )
-                                    if (entity != null) {
-                                        songsToUpsert.add(entity)
+                                    if (metadata != null) {
+                                        songsToUpsert.add(metadata)
                                     }
                                 } catch (e: Exception) {
                                     Log.e(TAG, "处理歌曲失败: ${deviceSong.fileName}", e)
@@ -492,13 +496,20 @@ class SongRepositoryImpl(
                     database.withTransaction {
                         if (songsToUpsert.isNotEmpty()) {
                             songsToUpsert.chunked(BATCH_SIZE).forEach { chunk ->
-                                songDao.upsertAll(chunk)
+                                songDao.upsertAll(chunk.map { it.entity })
+                                chunk.forEach { metadata ->
+                                    customTagKeyRepository.replaceForSong(
+                                        songUri = metadata.entity.uri,
+                                        customFields = metadata.customFields
+                                    )
+                                }
                             }
                         }
 
                         if (allDeletedUris.isNotEmpty()) {
                             allDeletedUris.chunked(BATCH_SIZE).forEach { chunk ->
                                 songDao.deleteByUris(chunk.toList())
+                                customTagKeyRepository.removeSongs(chunk.toList())
                             }
                         }
 
@@ -517,7 +528,7 @@ class SongRepositoryImpl(
                         folderDao.performPostScanCleanup()
                     }
                     if (songsToUpsert.isNotEmpty()) {
-                        val indexedSongs = songDao.getSongsByUris(songsToUpsert.map { it.uri })
+                        val indexedSongs = songDao.getSongsByUris(songsToUpsert.map { it.entity.uri })
                         libraryIndexRepository.reindexSongs(indexedSongs)
                     }
                     if (allDeletedUris.isNotEmpty() || missingSafFolderIds.isNotEmpty()) {
@@ -595,12 +606,17 @@ class SongRepositoryImpl(
         }
     }
 
+    private data class ScannedSongMetadata(
+        val entity: SongEntity,
+        val customFields: List<CustomTagField>,
+    )
+
     private suspend fun extractSongMetadata(
         songFile: SongFile,
         folderId: Long,
         existingId: Long = 0L,
         source: String = "MEDIA_STORE"
-    ): SongEntity? = withContext(Dispatchers.IO) {
+    ): ScannedSongMetadata? = withContext(Dispatchers.IO) {
         try {
 
             val audioData = context.contentResolver.openFileDescriptor(
@@ -609,7 +625,7 @@ class SongRepositoryImpl(
                 AudioTagReader.read(pfd, readPictures = false)
             } ?: return@withContext null
 
-            return@withContext SongEntity(
+            val entity = SongEntity(
                 id = existingId,
                 mediaId = songFile.mediaId,
                 source = source,
@@ -647,6 +663,10 @@ class SongRepositoryImpl(
                 fileAdded = songFile.dateAdded,
                 folderId = folderId
             ).withSortKeysUpdated()
+            return@withContext ScannedSongMetadata(
+                entity = entity,
+                customFields = audioData.customFields,
+            )
         } catch (e: Exception) {
             Log.e(TAG, "解析元数据失败: ${songFile.fileName}", e)
             null
@@ -725,6 +745,7 @@ class SongRepositoryImpl(
 
             database.withTransaction {
                 songDao.update(updatedSong)
+                customTagKeyRepository.replaceForSong(contentUri, audioTagData.customFields)
                 libraryIndexRepository.reindexSongInTransaction(updatedSong)
             }
 
@@ -1239,7 +1260,10 @@ class SongRepositoryImpl(
 
     override suspend fun clearAll() {
         withContext(Dispatchers.IO) {
-            songDao.clear()
+            database.withTransaction {
+                songDao.clear()
+                customTagKeyRepository.clearAll()
+            }
             libraryIndexRepository.refreshAndPruneIndexes()
             Log.d(TAG, "所有歌曲数据已清空")
         }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/di/AppModule.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/di/AppModule.kt
@@ -10,6 +10,8 @@ import com.lonx.lyrico.data.repository.BatchTaskRepository
 import com.lonx.lyrico.data.repository.BatchTaskRepositoryImpl
 import com.lonx.lyrico.data.repository.AppLogRepository
 import com.lonx.lyrico.data.repository.AppLogRepositoryImpl
+import com.lonx.lyrico.data.repository.CustomTagKeyRepository
+import com.lonx.lyrico.data.repository.CustomTagSettingsRepository
 import com.lonx.lyrico.data.repository.GhContributorRepository
 import com.lonx.lyrico.data.repository.GhContributorRepositoryImpl
 import com.lonx.lyrico.data.repository.LibraryIndexRepository
@@ -65,6 +67,7 @@ import com.lonx.lyrico.viewmodel.BatchRenameViewModel
 import com.lonx.lyrico.viewmodel.BatchReplayGainViewModel
 import com.lonx.lyrico.viewmodel.CoverSearchViewModel
 import com.lonx.lyrico.viewmodel.CharacterMappingViewModel
+import com.lonx.lyrico.viewmodel.CustomTagManagementViewModel
 import com.lonx.lyrico.viewmodel.EditFieldVisibilitySettingsViewModel
 import com.lonx.lyrico.viewmodel.EditMetadataViewModel
 import com.lonx.lyrico.viewmodel.FolderManagerViewModel
@@ -160,7 +163,8 @@ val appModule = module {
                 LyricoDatabase.MIGRATION_9_10,
                 LyricoDatabase.MIGRATION_10_11,
                 LyricoDatabase.MIGRATION_11_12,
-                LyricoDatabase.MIGRATION_12_13
+                LyricoDatabase.MIGRATION_12_13,
+                LyricoDatabase.MIGRATION_13_14
             )
             .build()
     }
@@ -168,13 +172,16 @@ val appModule = module {
     single { get<LyricoDatabase>().appLogDao() }
     single { get<LyricoDatabase>().libraryIndexDao() }
     single { get<LyricoDatabase>().sourcePluginDao() }
+    single { get<LyricoDatabase>().songCustomTagKeyDao() }
     single<SettingsRepository> { SettingsRepositoryImpl(androidContext()) }
+    single { CustomTagSettingsRepository(androidContext(), get()) }
+    single { CustomTagKeyRepository(get()) }
     single<PluginFieldProcessConfigRepository> { PluginFieldProcessConfigRepositoryImpl(androidContext(), get()) }
     single { EditFieldVisibilityRepository(androidContext()) }
     single<UpdateRepository> { UpdateRepositoryImpl(get(), get()) }
     single<PlaybackRepository> { PlaybackRepositoryImpl() }
     single<LibraryIndexRepository> { LibraryIndexRepositoryImpl(get(), get<LyricoDatabase>().songDao(), get(), get()) }
-    single<SongRepository> { SongRepositoryImpl(get(), androidContext(), get(), get(), get(), get(), get()) }
+    single<SongRepository> { SongRepositoryImpl(get(), androidContext(), get(), get(), get(), get(), get(), get()) }
     single<SourcePluginRepository> { SourcePluginRepositoryImpl(get()) }
     single<LibraryScanManager> { LibraryScanManagerImpl(get(), androidContext(), get(), get()) }
     single<BatchTaskRepository> { BatchTaskRepositoryImpl(get()) }
@@ -220,8 +227,9 @@ val appModule = module {
     viewModel { SearchViewModel(get(), get(), get(), get()) }
     viewModel { CoverSearchViewModel(get(), get(), get()) }
     viewModel { SearchSourceConfigViewModel(get(), get(), get()) }
-    viewModel { EditMetadataViewModel(get(), get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { EditMetadataViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     viewModel { EditFieldVisibilitySettingsViewModel(get()) }
+    viewModel { CustomTagManagementViewModel(get(), get()) }
     viewModel { BatchMatchViewModel(get(), get(), get(), get(), get(), get()) }
     viewModel { AppLogViewModel(get(),get()) }
     viewModel { PluginViewModel(get(), get(), get(), get(), get(), get()) }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/di/AppModule.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/di/AppModule.kt
@@ -238,7 +238,7 @@ val appModule = module {
     viewModel { BatchRenameViewModel(get(), get(), get(), get(), get()) }
     viewModel { CharacterMappingViewModel(get()) }
     viewModel { BatchExportViewModel(get(), get(), get()) }
-    viewModel { BatchEditViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { BatchEditViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { BatchReplayGainViewModel(get(), get(), get()) }
     viewModel { BatchLyricsFormatViewModel(get(), get(), get()) }
     viewModel { (taskId: String) -> BatchTaskDetailViewModel(taskId, get(), get()) }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
@@ -99,6 +99,7 @@ import top.yukonga.miuix.kmp.icon.basic.ArrowUpDown
 import top.yukonga.miuix.kmp.icon.extended.Add
 import top.yukonga.miuix.kmp.icon.extended.Back
 import top.yukonga.miuix.kmp.icon.extended.Close
+import top.yukonga.miuix.kmp.icon.extended.Delete
 import top.yukonga.miuix.kmp.icon.extended.Info
 import top.yukonga.miuix.kmp.icon.extended.Ok
 import top.yukonga.miuix.kmp.icon.extended.Settings
@@ -761,12 +762,19 @@ fun BatchEditScreen(
                                                                     .firstOrNull { it.key == key }
                                                                     ?.value
                                                                     ?: "<keep>",
+                                                                clear = key in uiState.customFieldClearKeys,
                                                                 onValueChange = { value ->
-                                                                    viewModel.updateCustomFieldValue(
+                                                                    viewModel.setCustomFieldValue(
                                                                         key = key,
                                                                         value = value
                                                                     )
-                                                                }
+                                                                },
+                                                                onKeep = {
+                                                                    viewModel.keepCustomField(key)
+                                                                },
+                                                                onClear = {
+                                                                    viewModel.clearCustomField(key)
+                                                                },
                                                             )
                                                         }
                                                     }
@@ -1699,9 +1707,18 @@ private fun BatchEditFieldItem(
 private fun BatchEditCustomFieldItem(
     keyName: String,
     value: String,
+    clear: Boolean,
     onValueChange: (String) -> Unit,
+    onKeep: () -> Unit,
+    onClear: () -> Unit,
 ) {
     val isKeep = value == "<keep>"
+    val displayedValue = if (clear) "" else value
+    val labelSuffix = when {
+        clear -> " (" + stringResource(R.string.batch_custom_tag_clear) + ")"
+        isKeep -> " (" + stringResource(R.string.batch_custom_tag_keep) + ")"
+        else -> " (" + stringResource(R.string.batch_custom_tag_set) + ")"
+    }
 
     Column(modifier = Modifier.padding(vertical = 6.dp)) {
         Row(
@@ -1719,28 +1736,46 @@ private fun BatchEditCustomFieldItem(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)
             )
-            IconButton(onClick = {
-                onValueChange(if (isKeep) "" else "<keep>")
-            }) {
-                Icon(
-                    imageVector = if (isKeep) MiuixIcons.Close else MiuixIcons.Undo,
-                    contentDescription = null,
-                    tint = if (isKeep)
-                        MiuixTheme.colorScheme.primary
-                    else
-                        MiuixTheme.colorScheme.error
-                )
+            Row {
+                IconButton(onClick = {
+                    if (isKeep) onValueChange("") else onKeep()
+                }) {
+                    Icon(
+                        imageVector = if (isKeep) MiuixIcons.Close else MiuixIcons.Undo,
+                        contentDescription = null,
+                        tint = if (isKeep)
+                            MiuixTheme.colorScheme.primary
+                        else
+                            MiuixTheme.colorScheme.error
+                    )
+                }
+                IconButton(onClick = onClear) {
+                    Icon(
+                        MiuixIcons.Delete,
+                        contentDescription = stringResource(R.string.batch_custom_tag_clear),
+                        tint = MiuixTheme.colorScheme.error
+                    )
+                }
             }
         }
 
-        TextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            value = value,
-            onValueChange = onValueChange,
-            label = keyName + if (isKeep) " (无修改)" else "",
-        )
+        if (clear) {
+            Text(
+                text = stringResource(R.string.batch_custom_tag_clear_summary),
+                style = MiuixTheme.textStyles.footnote1,
+                color = MiuixTheme.colorScheme.error,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+            )
+        } else {
+            TextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                value = displayedValue,
+                onValueChange = onValueChange,
+                label = keyName + labelSuffix,
+            )
+        }
     }
 }
 

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
@@ -99,7 +99,6 @@ import top.yukonga.miuix.kmp.icon.basic.ArrowUpDown
 import top.yukonga.miuix.kmp.icon.extended.Add
 import top.yukonga.miuix.kmp.icon.extended.Back
 import top.yukonga.miuix.kmp.icon.extended.Close
-import top.yukonga.miuix.kmp.icon.extended.Delete
 import top.yukonga.miuix.kmp.icon.extended.Info
 import top.yukonga.miuix.kmp.icon.extended.Ok
 import top.yukonga.miuix.kmp.icon.extended.Settings
@@ -135,6 +134,7 @@ fun BatchEditScreen(
     var showAddCustomTagDialog by remember { mutableStateOf(false) }
     var showSelectedValueSheet by remember { mutableStateOf(false) }
     var selectedValueField by remember { mutableStateOf<BatchEditField?>(null) }
+    var selectedCustomValueKey by remember { mutableStateOf<String?>(null) }
     var selectedValueOptions by remember { mutableStateOf<List<BatchEditSelectableValue>>(emptyList()) }
     var selectedValueOptionsLoading by remember { mutableStateOf(false) }
     var expandedFabMenu by remember { mutableStateOf(false) }
@@ -191,11 +191,24 @@ fun BatchEditScreen(
 
     fun openSelectedValueSheet(field: BatchEditField) {
         selectedValueField = field
+        selectedCustomValueKey = null
         selectedValueOptions = emptyList()
         selectedValueOptionsLoading = true
         showSelectedValueSheet = true
         scope.launch {
             selectedValueOptions = viewModel.getSelectedSongFieldValues(field)
+            selectedValueOptionsLoading = false
+        }
+    }
+
+    fun openSelectedCustomValueSheet(key: String) {
+        selectedValueField = null
+        selectedCustomValueKey = key
+        selectedValueOptions = emptyList()
+        selectedValueOptionsLoading = true
+        showSelectedValueSheet = true
+        scope.launch {
+            selectedValueOptions = viewModel.getSelectedSongCustomTagValues(key)
             selectedValueOptionsLoading = false
         }
     }
@@ -762,7 +775,6 @@ fun BatchEditScreen(
                                                                     .firstOrNull { it.key == key }
                                                                     ?.value
                                                                     ?: "<keep>",
-                                                                clear = key in uiState.customFieldClearKeys,
                                                                 onValueChange = { value ->
                                                                     viewModel.setCustomFieldValue(
                                                                         key = key,
@@ -772,8 +784,8 @@ fun BatchEditScreen(
                                                                 onKeep = {
                                                                     viewModel.keepCustomField(key)
                                                                 },
-                                                                onClear = {
-                                                                    viewModel.clearCustomField(key)
+                                                                onSelectFromSongs = {
+                                                                    openSelectedCustomValueSheet(key)
                                                                 },
                                                             )
                                                         }
@@ -960,7 +972,8 @@ fun BatchEditScreen(
     WindowBottomSheet(
         show = showSelectedValueSheet,
         enableNestedScroll = false,
-        title = selectedValueField?.let { stringResource(it.labelResId) }.orEmpty(),
+        title = selectedValueField?.let { stringResource(it.labelResId) }
+            ?: selectedCustomValueKey.orEmpty(),
         onDismissRequest = { showSelectedValueSheet = false }
     ) {
         Column(
@@ -1002,6 +1015,9 @@ fun BatchEditScreen(
                                     onClick = {
                                         selectedValueField?.let { field ->
                                             applySelectedValue(field, option.value)
+                                        }
+                                        selectedCustomValueKey?.let { key ->
+                                            viewModel.setCustomFieldValue(key, option.value)
                                         }
                                         showSelectedValueSheet = false
                                     }
@@ -1707,38 +1723,27 @@ private fun BatchEditFieldItem(
 private fun BatchEditCustomFieldItem(
     keyName: String,
     value: String,
-    clear: Boolean,
     onValueChange: (String) -> Unit,
     onKeep: () -> Unit,
-    onClear: () -> Unit,
+    onSelectFromSongs: () -> Unit,
 ) {
     val isKeep = value == "<keep>"
-    val displayedValue = if (clear) "" else value
-    val labelSuffix = when {
-        clear -> " (" + stringResource(R.string.batch_custom_tag_clear) + ")"
-        isKeep -> " (" + stringResource(R.string.batch_custom_tag_keep) + ")"
-        else -> " (" + stringResource(R.string.batch_custom_tag_set) + ")"
-    }
 
-    Column(modifier = Modifier.padding(vertical = 6.dp)) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = keyName,
-                style = MiuixTheme.textStyles.body2,
-                color = MiuixTheme.colorScheme.onSurface,
-                fontWeight = FontWeight.Medium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
+    TextField(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        value = value,
+        onValueChange = onValueChange,
+        label = keyName + if (isKeep) " (无修改)" else "",
+        trailingIcon = {
             Row {
                 IconButton(onClick = {
-                    if (isKeep) onValueChange("") else onKeep()
+                    if (isKeep) {
+                        onValueChange("")
+                    } else {
+                        onKeep()
+                    }
                 }) {
                     Icon(
                         imageVector = if (isKeep) MiuixIcons.Close else MiuixIcons.Undo,
@@ -1749,33 +1754,14 @@ private fun BatchEditCustomFieldItem(
                             MiuixTheme.colorScheme.error
                     )
                 }
-                IconButton(onClick = onClear) {
+                IconButton(onClick = onSelectFromSongs) {
                     Icon(
-                        MiuixIcons.Delete,
-                        contentDescription = stringResource(R.string.batch_custom_tag_clear),
-                        tint = MiuixTheme.colorScheme.error
+                        imageVector = MiuixIcons.Basic.ArrowUpDown,
+                        contentDescription = stringResource(R.string.batch_edit_select_from_selected_songs)
                     )
                 }
             }
         }
-
-        if (clear) {
-            Text(
-                text = stringResource(R.string.batch_custom_tag_clear_summary),
-                style = MiuixTheme.textStyles.footnote1,
-                color = MiuixTheme.colorScheme.error,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
-            )
-        } else {
-            TextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 4.dp),
-                value = displayedValue,
-                onValueChange = onValueChange,
-                label = keyName + labelSuffix,
-            )
-        }
-    }
+    )
 }
 

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
@@ -739,49 +739,6 @@ fun BatchEditScreen(
                                         }
                                     }
 
-                                    // 自定义标签组
-                                    if (
-                                        visibleGroupCodes.contains(EditFieldRegistry.GROUP_CUSTOM_TAGS) &&
-                                        visibleFieldCodes.contains("custom_tags.custom_tags") &&
-                                        uiState.customFields.isNotEmpty()
-                                    ) {
-                                        item(key = "custom_fields") {
-                                            SmallTitle(text = stringResource(R.string.group_custom_tags))
-                                            Card(
-                                                modifier = Modifier.padding(
-                                                    horizontal = 12.dp,
-                                                    vertical = 6.dp
-                                                )
-                                            ) {
-                                                Column(modifier = Modifier.padding(vertical = 6.dp)) {
-                                                    uiState.customFields.forEachIndexed { index, field ->
-                                                        BatchEditCustomFieldItem(
-                                                            field = field,
-                                                            onKeyChange = { newKey ->
-                                                                viewModel.updateCustomField(
-                                                                    index,
-                                                                    newKey,
-                                                                    field.value
-                                                                )
-                                                            },
-                                                            onValueChange = { newValue ->
-                                                                viewModel.updateCustomField(
-                                                                    index,
-                                                                    field.key,
-                                                                    newValue
-                                                                )
-                                                            },
-                                                            onRemove = {
-                                                                viewModel.removeCustomField(
-                                                                    index
-                                                                )
-                                                            }
-                                                        )
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
                                     // 歌词组
                                     if (visibleGroupCodes.contains(EditFieldRegistry.GROUP_LYRICS)) {
                                         item(key = "lyrics") {
@@ -860,18 +817,9 @@ fun BatchEditScreen(
             style = ExpandableFabMenuStyle.default().copy(
                 mainIcon = MiuixIcons.Add
             ),
-            itemCount = 3,
+            itemCount = 2,
             onExpandedChange = { expandedFabMenu = it }
         ) {
-            FabMenuItem(
-                label = stringResource(R.string.action_add_custom_tag),
-                icon = MiuixIcons.Add,
-                enabled = !uiState.isSaving,
-                onClick = {
-                    expandedFabMenu = false
-                    showAddCustomTagDialog = true
-                }
-            )
             FabMenuItem(
                 label = stringResource(R.string.edit_field_visibility_settings),
                 icon = MiuixIcons.Settings,

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/BatchEditScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,7 +58,6 @@ import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import com.lonx.audiotag.model.CustomTagField
 import com.lonx.lyrico.R
 import com.lonx.lyrico.data.editfield.EditFieldRegistry
 import com.lonx.lyrico.ui.components.rememberTintedPainter
@@ -99,7 +99,6 @@ import top.yukonga.miuix.kmp.icon.basic.ArrowUpDown
 import top.yukonga.miuix.kmp.icon.extended.Add
 import top.yukonga.miuix.kmp.icon.extended.Back
 import top.yukonga.miuix.kmp.icon.extended.Close
-import top.yukonga.miuix.kmp.icon.extended.Delete
 import top.yukonga.miuix.kmp.icon.extended.Info
 import top.yukonga.miuix.kmp.icon.extended.Ok
 import top.yukonga.miuix.kmp.icon.extended.Settings
@@ -125,6 +124,7 @@ fun BatchEditScreen(
     val viewModel: BatchEditViewModel = koinViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val visibleFieldGroups by viewModel.visibleFieldGroups.collectAsStateWithLifecycle()
+    val visibleCustomKeys by viewModel.visibleCustomKeys.collectAsStateWithLifecycle()
 
     var showCoverOptionsSheet by remember { mutableStateOf(false) }
     var showSelectedCoverSheet by remember { mutableStateOf(false) }
@@ -150,6 +150,10 @@ fun BatchEditScreen(
         .toSet()
     val editPreviews = remember(uiState, visibleFieldCodes) {
         viewModel.buildEditPreviews(visibleFieldCodes)
+    }
+
+    LaunchedEffect(visibleCustomKeys, uiState.selectedSongsVersion) {
+        viewModel.loadCustomTagPreviewValues(visibleCustomKeys)
     }
 
     val photoPickerLauncher = rememberLauncherForActivityResult(
@@ -739,6 +743,38 @@ fun BatchEditScreen(
                                         }
                                     }
 
+                                    if (visibleCustomKeys.isNotEmpty()) {
+                                        item(key = "custom_fields") {
+                                            Column {
+                                                SmallTitle(text = stringResource(R.string.group_custom_tags))
+                                                Card(
+                                                    modifier = Modifier.padding(
+                                                        horizontal = 12.dp,
+                                                        vertical = 6.dp
+                                                    )
+                                                ) {
+                                                    Column(modifier = Modifier.padding(vertical = 6.dp)) {
+                                                        visibleCustomKeys.forEach { key ->
+                                                            BatchEditCustomFieldItem(
+                                                                keyName = key,
+                                                                value = uiState.customFields
+                                                                    .firstOrNull { it.key == key }
+                                                                    ?.value
+                                                                    ?: "<keep>",
+                                                                onValueChange = { value ->
+                                                                    viewModel.updateCustomFieldValue(
+                                                                        key = key,
+                                                                        value = value
+                                                                    )
+                                                                }
+                                                            )
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
                                     // 歌词组
                                     if (visibleGroupCodes.contains(EditFieldRegistry.GROUP_LYRICS)) {
                                         item(key = "lyrics") {
@@ -817,9 +853,18 @@ fun BatchEditScreen(
             style = ExpandableFabMenuStyle.default().copy(
                 mainIcon = MiuixIcons.Add
             ),
-            itemCount = 2,
+            itemCount = 3,
             onExpandedChange = { expandedFabMenu = it }
         ) {
+            FabMenuItem(
+                label = stringResource(R.string.action_add_custom_tag),
+                icon = MiuixIcons.Add,
+                enabled = !uiState.isSaving,
+                onClick = {
+                    expandedFabMenu = false
+                    showAddCustomTagDialog = true
+                }
+            )
             FabMenuItem(
                 label = stringResource(R.string.edit_field_visibility_settings),
                 icon = MiuixIcons.Settings,
@@ -1149,20 +1194,14 @@ fun BatchEditScreen(
         }
     }
 
-    // 添加自定义标签 BottomSheet
     WindowDialog(
         show = showAddCustomTagDialog,
         title = stringResource(R.string.action_add_custom_tag),
         onDismissRequest = { showAddCustomTagDialog = false }
     ) {
-        // 临时存储新自定义标签内容
         var newCustomTagKey by remember { mutableStateOf("") }
         var newCustomTagValue by remember { mutableStateOf("") }
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-        ) {
-
+        Column(modifier = Modifier.fillMaxWidth()) {
             TextField(
                 value = newCustomTagKey,
                 onValueChange = { newCustomTagKey = it },
@@ -1178,14 +1217,10 @@ fun BatchEditScreen(
             )
 
             Spacer(modifier = Modifier.height(12.dp))
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
+            Row(horizontalArrangement = Arrangement.SpaceBetween) {
                 TextButton(
                     text = stringResource(R.string.cancel),
-                    onClick = {
-                        showAddCustomTagDialog = false
-                    },
+                    onClick = { showAddCustomTagDialog = false },
                     modifier = Modifier.weight(1f),
                 )
                 Spacer(Modifier.width(20.dp))
@@ -1193,11 +1228,9 @@ fun BatchEditScreen(
                     text = stringResource(R.string.confirm),
                     onClick = {
                         if (newCustomTagKey.isNotBlank()) {
-                            viewModel.addCustomField(
-                                CustomTagField(
-                                    newCustomTagKey,
-                                    newCustomTagValue
-                                )
+                            viewModel.addCustomFieldAndShow(
+                                key = newCustomTagKey,
+                                value = newCustomTagValue,
                             )
                             showAddCustomTagDialog = false
                         }
@@ -1208,6 +1241,7 @@ fun BatchEditScreen(
             }
         }
     }
+
 }
 
 @Composable
@@ -1663,11 +1697,12 @@ private fun BatchEditFieldItem(
  */
 @Composable
 private fun BatchEditCustomFieldItem(
-    field: CustomTagField,
-    onKeyChange: (String) -> Unit,
+    keyName: String,
+    value: String,
     onValueChange: (String) -> Unit,
-    onRemove: () -> Unit
 ) {
+    val isKeep = value == "<keep>"
+
     Column(modifier = Modifier.padding(vertical = 6.dp)) {
         Row(
             modifier = Modifier
@@ -1676,15 +1711,24 @@ private fun BatchEditCustomFieldItem(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = stringResource(R.string.label_custom_tag),
+                text = keyName,
                 style = MiuixTheme.textStyles.body2,
-                color = MiuixTheme.colorScheme.onSurfaceVariantSummary
+                color = MiuixTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
             )
-            Spacer(modifier = Modifier.weight(1f))
-            IconButton(onClick = onRemove) {
+            IconButton(onClick = {
+                onValueChange(if (isKeep) "" else "<keep>")
+            }) {
                 Icon(
-                    MiuixIcons.Delete,
-                    contentDescription = stringResource(R.string.action_remove_custom_tag)
+                    imageVector = if (isKeep) MiuixIcons.Close else MiuixIcons.Undo,
+                    contentDescription = null,
+                    tint = if (isKeep)
+                        MiuixTheme.colorScheme.primary
+                    else
+                        MiuixTheme.colorScheme.error
                 )
             }
         }
@@ -1693,17 +1737,9 @@ private fun BatchEditCustomFieldItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 4.dp),
-            value = field.key,
-            onValueChange = onKeyChange,
-            label = stringResource(R.string.label_custom_tag_name)
-        )
-        TextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp),
-            value = field.value,
+            value = value,
             onValueChange = onValueChange,
-            label = stringResource(R.string.label_custom_tag_value)
+            label = keyName + if (isKeep) " (无修改)" else "",
         )
     }
 }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/CustomTagManagementScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/CustomTagManagementScreen.kt
@@ -1,0 +1,297 @@
+package com.lonx.lyrico.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.lonx.lyrico.R
+import com.lonx.lyrico.ui.components.scaffoldContentPadding
+import com.lonx.lyrico.viewmodel.CustomTagManagementViewModel
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import org.koin.androidx.compose.koinViewModel
+import top.yukonga.miuix.kmp.basic.ButtonDefaults
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.IconButton
+import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
+import top.yukonga.miuix.kmp.basic.Scaffold
+import top.yukonga.miuix.kmp.basic.SmallTitle
+import top.yukonga.miuix.kmp.basic.SmallTopAppBar
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.basic.TextField
+import top.yukonga.miuix.kmp.icon.MiuixIcons
+import top.yukonga.miuix.kmp.icon.extended.Back
+import top.yukonga.miuix.kmp.icon.extended.Search
+import top.yukonga.miuix.kmp.preference.ArrowPreference
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+import top.yukonga.miuix.kmp.utils.overScrollVertical
+import top.yukonga.miuix.kmp.utils.scrollEndHaptic
+import top.yukonga.miuix.kmp.window.WindowDialog
+
+@Composable
+@Destination<RootGraph>(route = "custom_tag_management")
+fun CustomTagManagementScreen(
+    navigator: DestinationsNavigator,
+) {
+    val viewModel: CustomTagManagementViewModel = koinViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+    var showAddDialog by remember { mutableStateOf(false) }
+    val scrollBehavior = MiuixScrollBehavior()
+
+    val visibleItems = uiState.visibleKeys.map { key -> key to uiState.keyCounts[key] }
+    val discoveredItems = uiState.keyCounts
+        .filterKeys { key ->
+            uiState.searchQuery.isBlank() ||
+                key.contains(uiState.searchQuery, ignoreCase = true)
+        }
+        .toList()
+        .sortedWith(
+            compareByDescending<Pair<String, Int>> { it.second }
+                .thenBy { it.first.lowercase() }
+        )
+
+    Scaffold(
+        topBar = {
+            SmallTopAppBar(
+                title = stringResource(R.string.custom_tag_management_title),
+                navigationIcon = {
+                    IconButton(onClick = { navigator.popBackStack() }) {
+                        Icon(
+                            MiuixIcons.Back,
+                            contentDescription = stringResource(R.string.action_back)
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .scrollEndHaptic()
+                .overScrollVertical()
+                .nestedScroll(scrollBehavior.nestedScrollConnection)
+                .fillMaxHeight(),
+            contentPadding = scaffoldContentPadding(
+                paddingValues = paddingValues,
+                bottomExtra = 12.dp
+            ),
+            overscrollEffect = null,
+        ) {
+            item(key = "visible") {
+                SmallTitle(text = stringResource(R.string.custom_tag_visible_section))
+                Card(modifier = Modifier.padding(horizontal = 12.dp)) {
+                    Text(
+                        text = stringResource(R.string.custom_tag_visible_summary),
+                        style = MiuixTheme.textStyles.footnote1,
+                        color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                    if (visibleItems.isEmpty()) {
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                            Text(
+                                text = stringResource(R.string.custom_tag_empty_visible_title),
+                                fontWeight = FontWeight.Medium,
+                                color = MiuixTheme.colorScheme.onSurface,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = stringResource(R.string.custom_tag_empty_visible_summary),
+                                style = MiuixTheme.textStyles.footnote1,
+                                color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                            )
+                        }
+                    } else {
+                        visibleItems.forEach { (key, count) ->
+                            CustomTagRow(
+                                keyName = key,
+                                songCount = count,
+                                actionText = stringResource(R.string.custom_tag_remove_visible),
+                                onAction = { viewModel.removeVisibleKey(key) },
+                            )
+                        }
+                    }
+                    ArrowPreference(
+                        title = stringResource(R.string.custom_tag_add_key),
+                        summary = stringResource(R.string.custom_tag_remove_notice),
+                        onClick = { showAddDialog = true },
+                    )
+                }
+            }
+
+            item(key = "discovered") {
+                SmallTitle(text = stringResource(R.string.custom_tag_discovered_section))
+                Card(modifier = Modifier.padding(horizontal = 12.dp)) {
+                    Text(
+                        text = stringResource(R.string.custom_tag_discovered_summary),
+                        style = MiuixTheme.textStyles.footnote1,
+                        color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    )
+                    TextField(
+                        value = uiState.searchQuery,
+                        onValueChange = viewModel::updateSearchQuery,
+                        label = stringResource(R.string.custom_tag_search_hint),
+                        leadingIcon = {
+                            Icon(
+                                MiuixIcons.Search,
+                                contentDescription = stringResource(R.string.custom_tag_search_hint)
+                            )
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                    )
+                    discoveredItems.forEach { (key, count) ->
+                        val isVisible = key in uiState.visibleKeys
+                        CustomTagRow(
+                            keyName = key,
+                            songCount = count,
+                            actionText = stringResource(
+                                if (isVisible) {
+                                    R.string.custom_tag_already_visible
+                                } else {
+                                    R.string.custom_tag_add_to_visible
+                                }
+                            ),
+                            actionEnabled = !isVisible,
+                            onAction = { viewModel.addVisibleKey(key) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    AddCustomTagKeyDialog(
+        show = showAddDialog,
+        errorText = uiState.inputError,
+        onDismiss = {
+            showAddDialog = false
+            viewModel.clearInputError()
+        },
+        onConfirm = { key ->
+            viewModel.addVisibleKey(key)
+            showAddDialog = false
+        },
+    )
+}
+
+@Composable
+private fun CustomTagRow(
+    keyName: String,
+    songCount: Int?,
+    actionText: String,
+    actionEnabled: Boolean = true,
+    onAction: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = keyName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MiuixTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = if (songCount != null) {
+                    stringResource(R.string.custom_tag_song_count, songCount)
+                } else {
+                    stringResource(R.string.custom_tag_song_count, 0)
+                },
+                style = MiuixTheme.textStyles.footnote1,
+                color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+            )
+        }
+        TextButton(
+            text = actionText,
+            enabled = actionEnabled,
+            onClick = onAction,
+        )
+    }
+}
+
+@Composable
+private fun AddCustomTagKeyDialog(
+    show: Boolean,
+    errorText: String?,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    if (!show) return
+
+    WindowDialog(
+        show = show,
+        title = stringResource(R.string.custom_tag_add_key),
+        onDismissRequest = onDismiss,
+    ) {
+        var key by remember { mutableStateOf("") }
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = stringResource(R.string.custom_tag_key_hint),
+                style = MiuixTheme.textStyles.footnote1,
+                color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            TextField(
+                value = key,
+                onValueChange = { key = it },
+                label = stringResource(R.string.custom_tag_key),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (errorText != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = errorText,
+                    style = MiuixTheme.textStyles.footnote1,
+                    color = MiuixTheme.colorScheme.error,
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.SpaceBetween) {
+                TextButton(
+                    text = stringResource(R.string.cancel),
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(20.dp))
+                TextButton(
+                    text = stringResource(R.string.confirm),
+                    onClick = { onConfirm(key) },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.textButtonColorsPrimary(),
+                )
+            }
+        }
+    }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/EditMetadataScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/EditMetadataScreen.kt
@@ -784,7 +784,8 @@ fun EditMetadataScreen(
                             visibleCustomKeys.forEach { key ->
                                 val field = editingTagData?.customFields
                                     .orEmpty()
-                                    .firstOrNull { it.key == key }
+                                    .firstOrNull { it.key.equals(key, ignoreCase = true) }
+                                    ?.copy(key = key)
                                     ?: CustomTagField(
                                         key = key,
                                         value = "",
@@ -792,7 +793,8 @@ fun EditMetadataScreen(
 
                                 val originalField = originalTagData?.customFields
                                     .orEmpty()
-                                    .firstOrNull { it.key == key }
+                                    .firstOrNull { it.key.equals(key, ignoreCase = true) }
+                                    ?.copy(key = key)
 
                                 CustomMetadataFieldEditor(
                                     field = field,
@@ -1886,17 +1888,8 @@ private fun CustomMetadataFieldEditor(
                 }
             }
         }
-
-        Text(
-            text = field.key,
-            style = MiuixTheme.textStyles.body2,
-            color = MiuixTheme.colorScheme.onSurface,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 6.dp)
-        )
         MetadataInputField(
-            label = stringResource(R.string.label_custom_tag_value),
+            label = field.key,
             value = field.value,
             onValueChange = onValueChange,
             isModified = false,

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/EditMetadataScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/EditMetadataScreen.kt
@@ -156,6 +156,7 @@ fun EditMetadataScreen(
     val viewModel: EditMetadataViewModel = koinViewModel()
     val uiState by viewModel.uiState.collectAsState()
     val visibleFieldGroups by viewModel.visibleFieldGroups.collectAsState()
+    val visibleCustomKeys by viewModel.visibleCustomKeys.collectAsState()
     val limitLyricsInputLines by viewModel.limitLyricsInputLines.collectAsState()
     val replayGainCalculateProgress = uiState.replayGainCalculateProgress
     val originalTagData = uiState.originalTagData
@@ -776,67 +777,36 @@ fun EditMetadataScreen(
                     }
                 }
 
-                if (
-                    visibleGroupCodes.contains(EditFieldRegistry.GROUP_CUSTOM_TAGS) &&
-                    visibleFieldCodes.contains("custom_tags.custom_tags") &&
-                    !editingTagData?.customFields.isNullOrEmpty()
-                ) {
+                if (visibleCustomKeys.isNotEmpty()) {
                     item(key = "custom_fields") {
                         Column {
                             SmallTitle(text = stringResource(R.string.group_custom_tags))
-                            editingTagData.customFields.forEachIndexed { index, field ->
+                            visibleCustomKeys.forEach { key ->
+                                val field = editingTagData?.customFields
+                                    .orEmpty()
+                                    .firstOrNull { it.key == key }
+                                    ?: CustomTagField(
+                                        key = key,
+                                        value = "",
+                                    )
+
+                                val originalField = originalTagData?.customFields
+                                    .orEmpty()
+                                    .firstOrNull { it.key == key }
+
                                 CustomMetadataFieldEditor(
                                     field = field,
-                                    isModified = field != originalTagData?.customFields?.getOrNull(
-                                        index
-                                    ),
-                                    onKeyChange = { newKey ->
-                                        viewModel.updateTag {
-                                            copy(
-                                                customFields = customFields.toMutableList()
-                                                    .apply {
-                                                        this[index] =
-                                                            this[index].copy(key = newKey)
-                                                    }
-                                            )
-                                        }
-                                    },
+                                    isModified = originalField
+                                        ?.let { field != it }
+                                        ?: field.value.isNotEmpty(),
                                     onValueChange = { newValue ->
-                                        viewModel.updateTag {
-                                            copy(
-                                                customFields = customFields.toMutableList()
-                                                    .apply {
-                                                        this[index] =
-                                                            this[index].copy(value = newValue)
-                                                    }
-                                            )
-                                        }
+                                        viewModel.updateCustomFieldValue(key, newValue)
                                     },
                                     onRemove = {
-                                        viewModel.updateTag {
-                                            copy(
-                                                customFields = customFields.toMutableList()
-                                                    .apply {
-                                                        removeAt(index)
-                                                    }
-                                            )
-                                        }
+                                        viewModel.removeCustomFieldValue(key)
                                     },
                                     onRevert = {
-                                        viewModel.updateTag {
-                                            val originalField =
-                                                originalTagData?.customFields?.getOrNull(index)
-                                            copy(
-                                                customFields = customFields.toMutableList()
-                                                    .apply {
-                                                        if (originalField != null) {
-                                                            this[index] = originalField
-                                                        } else {
-                                                            removeAt(index)
-                                                        }
-                                                    }
-                                            )
-                                        }
+                                        viewModel.revertCustomField(key)
                                     }
                                 )
                             }
@@ -1374,14 +1344,10 @@ fun EditMetadataScreen(
                     text = stringResource(R.string.confirm),
                     onClick = {
                         if (newCustomTagKey.isNotBlank()) {
-                            viewModel.updateTag {
-                                copy(
-                                    customFields = customFields + CustomTagField(
-                                        newCustomTagKey,
-                                        newCustomTagValue
-                                    )
-                                )
-                            }
+                            viewModel.addCustomFieldAndShow(
+                                key = newCustomTagKey,
+                                value = newCustomTagValue,
+                            )
                             showAddCustomTagDialog = false
                         }
                     },
@@ -1864,7 +1830,6 @@ private fun MetadataInputField(
 private fun CustomMetadataFieldEditor(
     field: CustomTagField,
     isModified: Boolean,
-    onKeyChange: (String) -> Unit,
     onValueChange: (String) -> Unit,
     onRemove: () -> Unit,
     onRevert: () -> Unit
@@ -1922,12 +1887,13 @@ private fun CustomMetadataFieldEditor(
             }
         }
 
-        MetadataInputField(
-            label = stringResource(R.string.label_custom_tag_name),
-            value = field.key,
-            onValueChange = onKeyChange,
-            isModified = false,
-            onRevert = onRevert
+        Text(
+            text = field.key,
+            style = MiuixTheme.textStyles.body2,
+            color = MiuixTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 6.dp)
         )
         MetadataInputField(
             label = stringResource(R.string.label_custom_tag_value),

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/SettingsScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/SettingsScreen.kt
@@ -53,6 +53,7 @@ import com.ramcosta.composedestinations.generated.destinations.AboutDestination
 import com.ramcosta.composedestinations.generated.destinations.AppLogsDestination
 import com.ramcosta.composedestinations.generated.destinations.ArtistSplitSettingsDestination
 import com.ramcosta.composedestinations.generated.destinations.BatchTaskListDestination
+import com.ramcosta.composedestinations.generated.destinations.CustomTagManagementDestination
 import com.ramcosta.composedestinations.generated.destinations.EditFieldVisibilityDestination
 import com.ramcosta.composedestinations.generated.destinations.FolderManagerDestination
 import com.ramcosta.composedestinations.generated.destinations.PluginManagerDestination
@@ -522,6 +523,10 @@ fun SettingsScreen(
                     ArrowPreference(
                         title = stringResource(R.string.edit_field_visibility_settings),
                         onClick = { navigator.navigate(EditFieldVisibilityDestination()) }
+                    )
+                    ArrowPreference(
+                        title = stringResource(R.string.custom_tag_management_title),
+                        onClick = { navigator.navigate(CustomTagManagementDestination()) }
                     )
                 }
             }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
@@ -112,7 +112,6 @@ data class BatchEditUiState(
 
     /** 自定义标签 */
     val customFields: List<CustomTagField> = emptyList(),
-    val customFieldClearKeys: Set<String> = emptySet(),
 
     /** 保存进度显示相关字段 */
     val saveProgressBottomSheet: Boolean = false,  // 是否显示保存进度对话框
@@ -324,7 +323,6 @@ class BatchEditViewModel(
 
             state.copy(
                 customFields = nextFields,
-                customFieldClearKeys = state.customFieldClearKeys - normalizedKey,
             )
         }
     }
@@ -336,19 +334,6 @@ class BatchEditViewModel(
             state.copy(
                 customFields = state.customFields
                     .filterNot { it.key.equals(normalizedKey, ignoreCase = true) },
-                customFieldClearKeys = state.customFieldClearKeys - normalizedKey,
-            )
-        }
-    }
-
-    fun clearCustomField(key: String) {
-        val normalizedKey = normalizeCustomTagKey(key) ?: return
-
-        _uiState.update { state ->
-            state.copy(
-                customFields = state.customFields
-                    .filterNot { it.key.equals(normalizedKey, ignoreCase = true) },
-                customFieldClearKeys = state.customFieldClearKeys + normalizedKey,
             )
         }
     }
@@ -402,6 +387,33 @@ class BatchEditViewModel(
                         sourceUri = fieldValue.sourceUri
                     )
                 }
+        }
+
+    suspend fun getSelectedSongCustomTagValues(key: String): List<BatchEditSelectableValue> =
+        withContext(Dispatchers.IO) {
+            val normalizedKey = normalizeCustomTagKey(key) ?: return@withContext emptyList()
+            ensureSelectedSongsLoaded()
+
+            selectedSongs.mapNotNull { song ->
+                val value = try {
+                    songRepository.readAudioTagData(song.uri)
+                        .customFields
+                        .firstOrNull { field ->
+                            normalizeCustomTagKey(field.key) == normalizedKey
+                        }
+                        ?.value
+                } catch (e: Exception) {
+                    Log.e(TAG, "读取已选歌曲自定义标签失败: ${song.uri}", e)
+                    null
+                }?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+
+                BatchEditSelectableValue(
+                    title = value,
+                    summary = song.title?.takeIf { it.isNotBlank() } ?: song.fileName,
+                    value = value,
+                    sourceUri = song.uri
+                )
+            }.distinctBy { it.value }
         }
 
     private fun BatchEditField.databaseColumnName(): String? = when (this) {
@@ -596,21 +608,6 @@ class BatchEditViewModel(
                     )
                 }
 
-            state.customFieldClearKeys.forEach { key ->
-                val oldValue = customTagPreviewValues[song.uri]
-                    ?.get(normalizeCustomTagKey(key))
-                    .orEmpty()
-                if (oldValue.isNotEmpty()) {
-                    add(
-                        BatchEditPreviewChange(
-                            labelResId = null,
-                            customLabel = key,
-                            oldValue = oldValue,
-                            newValue = ""
-                        )
-                    )
-                }
-            }
         }
     }
 
@@ -722,9 +719,6 @@ class BatchEditViewModel(
             customFields = customFields
                 .filter { it.key.isNotBlank() && it.value != keep }
                 .distinctBy { it.key },
-            customFieldClearKeys = customFieldClearKeys
-                .mapNotNull { normalizeCustomTagKey(it) }
-                .toSet(),
         )
     }
 
@@ -828,10 +822,7 @@ class BatchEditViewModel(
             customFields = customFields
                 .filter { it.key.isNotBlank() && it.value != keep }
                 .distinctBy { it.key }
-                .map { EditTagsCustomField(key = it.key, value = it.value) } +
-                customFieldClearKeys.map { key ->
-                    EditTagsCustomField(key = key, value = null, clear = true)
-                }
+                .map { EditTagsCustomField(key = it.key, value = it.value) }
         )
     }
 
@@ -1008,12 +999,8 @@ class BatchEditViewModel(
             }
         }
 
-        if (state.customFields.isNotEmpty() || state.customFieldClearKeys.isNotEmpty()) {
+        if (state.customFields.isNotEmpty()) {
             tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
-                state.customFieldClearKeys.forEach { clearKey ->
-                    val key = normalizeCustomTagKey(clearKey) ?: return@forEach
-                    removeAll { it.key.equals(key, ignoreCase = true) }
-                }
                 state.customFields.forEach { newField ->
                     val key = normalizeCustomTagKey(newField.key) ?: return@forEach
                     val field = CustomTagField(key = key, value = newField.value)

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
@@ -18,6 +18,7 @@ import com.lonx.lyrico.data.model.BatchTaskType
 import com.lonx.lyrico.data.model.entity.SongEntity
 import com.lonx.lyrico.data.model.entity.getUri
 import com.lonx.lyrico.data.repository.BatchTaskRepository
+import com.lonx.lyrico.data.repository.CustomTagSettingsRepository
 import com.lonx.lyrico.data.repository.SongRepository
 import com.lonx.lyrico.utils.LyricEncoder
 import com.lonx.lyrico.utils.UiMessage
@@ -37,6 +38,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -118,7 +120,8 @@ data class BatchEditUiState(
     val skippedCount: Int = 0,  // 跳过计数
     val failureCount: Int = 0,  // 失败计数
     val saveTimeMillis: Long = 0,  // 保存总用时（毫秒）
-    val selectedSongsVersion: Int = 0
+    val selectedSongsVersion: Int = 0,
+    val customTagPreviewVersion: Int = 0
 )
 
 data class BatchEditPreview(
@@ -155,6 +158,7 @@ class BatchEditViewModel(
     private val batchTaskRepository: BatchTaskRepository,
     private val batchTaskScheduler: BatchTaskScheduler,
     private val editFieldVisibilityRepository: EditFieldVisibilityRepository,
+    private val customTagSettingsRepository: CustomTagSettingsRepository,
     private val application: Application
 ) : ViewModel() {
 
@@ -163,6 +167,7 @@ class BatchEditViewModel(
     private var saveJob: Job? = null
     private var observeJob: Job? = null
     private var currentTaskId: String? = null
+    private var customTagPreviewValues: Map<String, Map<String, String>> = emptyMap()
 
     private val _uiState = MutableStateFlow(BatchEditUiState())
     val uiState: StateFlow<BatchEditUiState> = _uiState.asStateFlow()
@@ -172,6 +177,15 @@ class BatchEditViewModel(
             .map { config ->
                 config.visibleGroupsForScene(EditFieldScene.BatchEdit)
             }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = emptyList(),
+            )
+
+    val visibleCustomKeys: StateFlow<List<String>> =
+        customTagSettingsRepository.settingsFlow
+            .map { it.visibleKeys }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
@@ -297,30 +311,41 @@ class BatchEditViewModel(
 
     // ── 自定义标签 ──────────────────────────────────────────
 
-    fun addCustomField(field: CustomTagField) {
-        _uiState.update { it.copy(customFields = it.customFields + field) }
-    }
+    fun updateCustomFieldValue(key: String, value: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
 
-    fun updateCustomField(index: Int, key: String, value: String) {
-        _uiState.update {
-            it.copy(
-                customFields = it.customFields.toMutableList().apply {
-                    this[index] = this[index].copy(key = key, value = value)
-                }
-            )
+        _uiState.update { state ->
+            val nextFields = state.customFields
+                .filterNot { it.key.equals(normalizedKey, ignoreCase = true) }
+                .toMutableList()
+
+            if (value != EditTagsTaskConfig.KEEP_VALUE) {
+                nextFields += CustomTagField(normalizedKey, value)
+            }
+
+            state.copy(customFields = nextFields)
         }
     }
 
-    fun removeCustomField(index: Int) {
-        _uiState.update {
-            it.copy(
-                customFields = it.customFields.toMutableList().apply {
-                    removeAt(index)
-                }
-            )
+    fun addCustomFieldAndShow(key: String, value: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
+        viewModelScope.launch {
+            customTagSettingsRepository.addVisibleKey(normalizedKey)
         }
+
+        updateCustomFieldValue(normalizedKey, value)
     }
 
+    private fun normalizeCustomTagKey(input: String): String? {
+        val key = input.trim()
+        return when {
+            key.isBlank() -> null
+            key.length > 64 -> null
+            key.any { it == '\n' || it == '\r' } -> null
+            else -> key.uppercase(Locale.ROOT)
+        }
+    }
 
     // ── 封面管理 ──────────────────────────────────────────
 
@@ -401,6 +426,35 @@ class BatchEditViewModel(
                 null
             }
         }
+
+    fun loadCustomTagPreviewValues(keys: List<String>) {
+        val normalizedKeys = keys.mapNotNull { normalizeCustomTagKey(it) }.toSet()
+        if (normalizedKeys.isEmpty() || selectedUris.isEmpty()) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            ensureSelectedSongsLoaded()
+            val values = selectedSongs.associate { song ->
+                val customValues = try {
+                    songRepository.readAudioTagData(song.uri)
+                        .customFields
+                        .mapNotNull { field ->
+                            val key = normalizeCustomTagKey(field.key) ?: return@mapNotNull null
+                            if (key in normalizedKeys) key to field.value else null
+                        }
+                        .toMap()
+                } catch (e: Exception) {
+                    Log.e(TAG, "读取自定义标签预览失败: ${song.uri}", e)
+                    emptyMap()
+                }
+                song.uri to customValues
+            }
+
+            customTagPreviewValues = values
+            _uiState.update {
+                it.copy(customTagPreviewVersion = it.customTagPreviewVersion + 1)
+            }
+        }
+    }
 
     fun buildEditPreviews(visibleFieldCodes: Set<String>): List<BatchEditPreview> {
         val state = _uiState.value.filterHiddenEditFields(visibleFieldCodes)
@@ -501,6 +555,20 @@ class BatchEditViewModel(
                 }
             }
 
+            state.customFields
+                .filter { it.key.isNotBlank() && it.value != keep }
+                .forEach { field ->
+                    add(
+                        BatchEditPreviewChange(
+                            labelResId = null,
+                            customLabel = field.key,
+                            oldValue = customTagPreviewValues[song.uri]
+                                ?.get(normalizeCustomTagKey(field.key))
+                                .orEmpty(),
+                            newValue = field.value
+                        )
+                    )
+                }
         }
     }
 
@@ -609,7 +677,9 @@ class BatchEditViewModel(
             } else {
                 keep
             },
-            customFields = emptyList(),
+            customFields = customFields
+                .filter { it.key.isNotBlank() && it.value != keep }
+                .distinctBy { it.key },
         )
     }
 
@@ -710,7 +780,10 @@ class BatchEditViewModel(
             } else {
                 keep
             },
-            customFields = emptyList()
+            customFields = customFields
+                .filter { it.key.isNotBlank() && it.value != keep }
+                .distinctBy { it.key }
+                .map { EditTagsCustomField(it.key, it.value) }
         )
     }
 
@@ -885,6 +958,21 @@ class BatchEditViewModel(
                     LyricEncoder.shiftLyricsOffset(tag.lyrics!!, offsetValue.toLong())
                 tag = tag.copy(lyrics = shiftedLyrics)
             }
+        }
+
+        if (state.customFields.isNotEmpty()) {
+            tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
+                state.customFields.forEach { newField ->
+                    val key = normalizeCustomTagKey(newField.key) ?: return@forEach
+                    val field = CustomTagField(key = key, value = newField.value)
+                    val existingIndex = indexOfFirst { it.key.equals(key, ignoreCase = true) }
+                    if (existingIndex >= 0) {
+                        this[existingIndex] = field
+                    } else {
+                        add(field)
+                    }
+                }
+            })
         }
 
         return tag

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
@@ -112,6 +112,7 @@ data class BatchEditUiState(
 
     /** 自定义标签 */
     val customFields: List<CustomTagField> = emptyList(),
+    val customFieldClearKeys: Set<String> = emptySet(),
 
     /** 保存进度显示相关字段 */
     val saveProgressBottomSheet: Boolean = false,  // 是否显示保存进度对话框
@@ -311,7 +312,7 @@ class BatchEditViewModel(
 
     // ── 自定义标签 ──────────────────────────────────────────
 
-    fun updateCustomFieldValue(key: String, value: String) {
+    fun setCustomFieldValue(key: String, value: String) {
         val normalizedKey = normalizeCustomTagKey(key) ?: return
 
         _uiState.update { state ->
@@ -319,11 +320,36 @@ class BatchEditViewModel(
                 .filterNot { it.key.equals(normalizedKey, ignoreCase = true) }
                 .toMutableList()
 
-            if (value != EditTagsTaskConfig.KEEP_VALUE) {
-                nextFields += CustomTagField(normalizedKey, value)
-            }
+            nextFields += CustomTagField(normalizedKey, value)
 
-            state.copy(customFields = nextFields)
+            state.copy(
+                customFields = nextFields,
+                customFieldClearKeys = state.customFieldClearKeys - normalizedKey,
+            )
+        }
+    }
+
+    fun keepCustomField(key: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
+        _uiState.update { state ->
+            state.copy(
+                customFields = state.customFields
+                    .filterNot { it.key.equals(normalizedKey, ignoreCase = true) },
+                customFieldClearKeys = state.customFieldClearKeys - normalizedKey,
+            )
+        }
+    }
+
+    fun clearCustomField(key: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
+        _uiState.update { state ->
+            state.copy(
+                customFields = state.customFields
+                    .filterNot { it.key.equals(normalizedKey, ignoreCase = true) },
+                customFieldClearKeys = state.customFieldClearKeys + normalizedKey,
+            )
         }
     }
 
@@ -334,7 +360,7 @@ class BatchEditViewModel(
             customTagSettingsRepository.addVisibleKey(normalizedKey)
         }
 
-        updateCustomFieldValue(normalizedKey, value)
+        setCustomFieldValue(normalizedKey, value)
     }
 
     private fun normalizeCustomTagKey(input: String): String? {
@@ -569,6 +595,22 @@ class BatchEditViewModel(
                         )
                     )
                 }
+
+            state.customFieldClearKeys.forEach { key ->
+                val oldValue = customTagPreviewValues[song.uri]
+                    ?.get(normalizeCustomTagKey(key))
+                    .orEmpty()
+                if (oldValue.isNotEmpty()) {
+                    add(
+                        BatchEditPreviewChange(
+                            labelResId = null,
+                            customLabel = key,
+                            oldValue = oldValue,
+                            newValue = ""
+                        )
+                    )
+                }
+            }
         }
     }
 
@@ -680,6 +722,9 @@ class BatchEditViewModel(
             customFields = customFields
                 .filter { it.key.isNotBlank() && it.value != keep }
                 .distinctBy { it.key },
+            customFieldClearKeys = customFieldClearKeys
+                .mapNotNull { normalizeCustomTagKey(it) }
+                .toSet(),
         )
     }
 
@@ -783,7 +828,10 @@ class BatchEditViewModel(
             customFields = customFields
                 .filter { it.key.isNotBlank() && it.value != keep }
                 .distinctBy { it.key }
-                .map { EditTagsCustomField(it.key, it.value) }
+                .map { EditTagsCustomField(key = it.key, value = it.value) } +
+                customFieldClearKeys.map { key ->
+                    EditTagsCustomField(key = key, value = null, clear = true)
+                }
         )
     }
 
@@ -960,8 +1008,12 @@ class BatchEditViewModel(
             }
         }
 
-        if (state.customFields.isNotEmpty()) {
+        if (state.customFields.isNotEmpty() || state.customFieldClearKeys.isNotEmpty()) {
             tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
+                state.customFieldClearKeys.forEach { clearKey ->
+                    val key = normalizeCustomTagKey(clearKey) ?: return@forEach
+                    removeAll { it.key.equals(key, ignoreCase = true) }
+                }
                 state.customFields.forEach { newField ->
                     val key = normalizeCustomTagKey(newField.key) ?: return@forEach
                     val field = CustomTagField(key = key, value = newField.value)

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/BatchEditViewModel.kt
@@ -501,20 +501,6 @@ class BatchEditViewModel(
                 }
             }
 
-            if (visible("custom_tags.custom_tags")) {
-                state.customFields
-                    .filter { it.key.isNotBlank() }
-                    .forEach { field ->
-                        add(
-                            BatchEditPreviewChange(
-                                labelResId = null,
-                                customLabel = field.key,
-                                oldValue = "",
-                                newValue = field.value
-                            )
-                        )
-                    }
-            }
         }
     }
 
@@ -623,7 +609,7 @@ class BatchEditViewModel(
             } else {
                 keep
             },
-            customFields = if (visible("custom_tags.custom_tags")) customFields else emptyList(),
+            customFields = emptyList(),
         )
     }
 
@@ -724,11 +710,7 @@ class BatchEditViewModel(
             } else {
                 keep
             },
-            customFields = if (visible("custom_tags.custom_tags")) {
-                customFields.map { EditTagsCustomField(it.key, it.value) }
-            } else {
-                emptyList()
-            }
+            customFields = emptyList()
         )
     }
 
@@ -903,20 +885,6 @@ class BatchEditViewModel(
                     LyricEncoder.shiftLyricsOffset(tag.lyrics!!, offsetValue.toLong())
                 tag = tag.copy(lyrics = shiftedLyrics)
             }
-        }
-
-        // 处理自定义标签
-        if (visible("custom_tags.custom_tags") && state.customFields.isNotEmpty()) {
-            tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
-                state.customFields.forEach { newField ->
-                    val existingIndex = indexOfFirst { it.key == newField.key }
-                    if (existingIndex >= 0) {
-                        this[existingIndex] = newField
-                    } else {
-                        add(newField)
-                    }
-                }
-            })
         }
 
         return tag

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/CustomTagManagementViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/CustomTagManagementViewModel.kt
@@ -1,0 +1,80 @@
+package com.lonx.lyrico.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lonx.lyrico.data.repository.CustomTagKeyRepository
+import com.lonx.lyrico.data.repository.CustomTagSettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class CustomTagManagementUiState(
+    val visibleKeys: List<String> = emptyList(),
+    val keyCounts: Map<String, Int> = emptyMap(),
+    val searchQuery: String = "",
+    val inputError: String? = null,
+)
+
+class CustomTagManagementViewModel(
+    private val customTagSettingsRepository: CustomTagSettingsRepository,
+    private val customTagKeyRepository: CustomTagKeyRepository,
+) : ViewModel() {
+
+    private val searchQuery = MutableStateFlow("")
+    private val inputError = MutableStateFlow<String?>(null)
+
+    val uiState: StateFlow<CustomTagManagementUiState> =
+        combine(
+            customTagSettingsRepository.settingsFlow,
+            customTagKeyRepository.observeKeyCounts(),
+            searchQuery,
+            inputError,
+        ) { settings, counts, query, error ->
+            CustomTagManagementUiState(
+                visibleKeys = settings.visibleKeys,
+                keyCounts = counts.associate { it.key to it.songCount },
+                searchQuery = query,
+                inputError = error,
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = CustomTagManagementUiState(),
+        )
+
+    fun updateSearchQuery(query: String) {
+        searchQuery.value = query
+    }
+
+    fun addVisibleKey(input: String) {
+        viewModelScope.launch {
+            runCatching {
+                customTagSettingsRepository.addVisibleKey(input)
+            }.onSuccess {
+                inputError.value = null
+            }.onFailure {
+                inputError.value = it.message
+            }
+        }
+    }
+
+    fun removeVisibleKey(key: String) {
+        viewModelScope.launch {
+            customTagSettingsRepository.removeVisibleKey(key)
+        }
+    }
+
+    fun setVisibleKeys(keys: List<String>) {
+        viewModelScope.launch {
+            customTagSettingsRepository.setVisibleKeys(keys)
+        }
+    }
+
+    fun clearInputError() {
+        inputError.update { null }
+    }
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lonx.audiotag.model.AudioPicture
 import com.lonx.audiotag.model.AudioTagData
+import com.lonx.audiotag.model.CustomTagField
 import com.lonx.lyrico.R
 import com.lonx.lyrico.data.editfield.EditFieldScene
 import com.lonx.lyrico.data.editfield.EditFieldVisibilityRepository
@@ -32,6 +33,7 @@ import com.lonx.lyrico.data.model.entity.SongEntity
 import com.lonx.lyrico.data.model.plugin.GlobalFieldProcessSettings
 import com.lonx.lyrico.data.model.plugin.defaultPluginFieldProcessConfig
 import com.lonx.lyrico.data.repository.AppLogRepository
+import com.lonx.lyrico.data.repository.CustomTagSettingsRepository
 import com.lonx.lyrico.data.repository.PluginFieldProcessConfigRepository
 import com.lonx.lyrico.data.repository.PlaybackRepository
 import com.lonx.lyrico.data.repository.SettingsDefaults
@@ -106,7 +108,8 @@ class EditMetadataViewModel(
     private val appLogRepository: AppLogRepository,
     private val editFieldVisibilityRepository: EditFieldVisibilityRepository,
     private val pluginFieldProcessConfigRepository: PluginFieldProcessConfigRepository,
-    private val searchSourceProvider: SearchSourceProvider
+    private val searchSourceProvider: SearchSourceProvider,
+    private val customTagSettingsRepository: CustomTagSettingsRepository,
 ) : ViewModel() {
 
     private val TAG = "EditMetadataVM"
@@ -154,6 +157,15 @@ class EditMetadataViewModel(
             .map { config ->
                 config.visibleGroupsForScene(EditFieldScene.SingleEdit)
             }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = emptyList(),
+            )
+
+    val visibleCustomKeys: StateFlow<List<String>> =
+        customTagSettingsRepository.settingsFlow
+            .map { it.visibleKeys }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
@@ -213,6 +225,59 @@ class EditMetadataViewModel(
                 isEditing = true
             )
         }
+    }
+
+    fun updateCustomFieldValue(key: String, value: String) {
+        updateTag {
+            val fields = customFields.toMutableList()
+            val index = fields.indexOfFirst { it.key == key }
+
+            if (index >= 0) {
+                fields[index] = fields[index].copy(value = value)
+            } else {
+                fields += CustomTagField(
+                    key = key,
+                    value = value,
+                )
+            }
+
+            copy(customFields = fields)
+        }
+    }
+
+    fun removeCustomFieldValue(key: String) {
+        updateTag {
+            copy(
+                customFields = customFields.filterNot { it.key == key }
+            )
+        }
+    }
+
+    fun revertCustomField(key: String) {
+        val original = _uiState.value.originalTagData
+            ?.customFields
+            .orEmpty()
+            .firstOrNull { it.key == key }
+
+        updateTag {
+            val fields = customFields
+                .filterNot { it.key == key }
+                .toMutableList()
+
+            if (original != null) {
+                fields += original
+            }
+
+            copy(customFields = fields)
+        }
+    }
+
+    fun addCustomFieldAndShow(key: String, value: String) {
+        viewModelScope.launch {
+            customTagSettingsRepository.addVisibleKey(key)
+        }
+
+        updateCustomFieldValue(key, value)
     }
     /**
      * 打开弹窗前准备：拍快照，并重置累计偏移量
@@ -687,7 +752,6 @@ class EditMetadataViewModel(
             } else {
                 base.replayGainReferenceLoudness
             },
-            customFields = if (visible("custom_tags.custom_tags")) customFields else base.customFields,
             lyrics = if (visible("lyrics.lyrics")) lyrics else base.lyrics,
             pictures = if (visible("cover.picture")) pictures else base.pictures,
             picUrl = if (visible("cover.picture")) picUrl else base.picUrl,

--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/EditMetadataViewModel.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 data class EditMetadataUiState(
     val songInfo: SongInfo? = null,
@@ -228,15 +229,17 @@ class EditMetadataViewModel(
     }
 
     fun updateCustomFieldValue(key: String, value: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
         updateTag {
             val fields = customFields.toMutableList()
-            val index = fields.indexOfFirst { it.key == key }
+            val index = fields.indexOfFirst { it.key.equals(normalizedKey, ignoreCase = true) }
 
             if (index >= 0) {
-                fields[index] = fields[index].copy(value = value)
+                fields[index] = fields[index].copy(key = normalizedKey, value = value)
             } else {
                 fields += CustomTagField(
-                    key = key,
+                    key = normalizedKey,
                     value = value,
                 )
             }
@@ -246,22 +249,26 @@ class EditMetadataViewModel(
     }
 
     fun removeCustomFieldValue(key: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
         updateTag {
             copy(
-                customFields = customFields.filterNot { it.key == key }
+                customFields = customFields.filterNot { it.key.equals(normalizedKey, ignoreCase = true) }
             )
         }
     }
 
     fun revertCustomField(key: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
         val original = _uiState.value.originalTagData
             ?.customFields
             .orEmpty()
-            .firstOrNull { it.key == key }
+            .firstOrNull { it.key.equals(normalizedKey, ignoreCase = true) }
+            ?.copy(key = normalizedKey)
 
         updateTag {
             val fields = customFields
-                .filterNot { it.key == key }
+                .filterNot { it.key.equals(normalizedKey, ignoreCase = true) }
                 .toMutableList()
 
             if (original != null) {
@@ -273,11 +280,23 @@ class EditMetadataViewModel(
     }
 
     fun addCustomFieldAndShow(key: String, value: String) {
+        val normalizedKey = normalizeCustomTagKey(key) ?: return
+
         viewModelScope.launch {
-            customTagSettingsRepository.addVisibleKey(key)
+            customTagSettingsRepository.addVisibleKey(normalizedKey)
         }
 
-        updateCustomFieldValue(key, value)
+        updateCustomFieldValue(normalizedKey, value)
+    }
+
+    private fun normalizeCustomTagKey(input: String): String? {
+        val key = input.trim()
+        return when {
+            key.isBlank() -> null
+            key.length > 64 -> null
+            key.any { it == '\n' || it == '\r' } -> null
+            else -> key.uppercase(Locale.ROOT)
+        }
     }
     /**
      * 打开弹窗前准备：拍快照，并重置累计偏移量

--- a/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
@@ -9,6 +9,7 @@ import com.lonx.lyrico.data.repository.SongRepository
 import com.lonx.lyrico.utils.LyricEncoder
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import java.util.Locale
 
 @Serializable
 data class EditTagsTaskConfig(
@@ -145,8 +146,9 @@ class EditTagsProcessor(
         if (config.customFields.isNotEmpty()) {
             tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
                 config.customFields.forEach { newField ->
-                    val field = CustomTagField(newField.key, newField.value)
-                    val existingIndex = indexOfFirst { it.key == field.key }
+                    val key = normalizeCustomTagKey(newField.key) ?: return@forEach
+                    val field = CustomTagField(key, newField.value)
+                    val existingIndex = indexOfFirst { it.key.equals(field.key, ignoreCase = true) }
                     if (existingIndex >= 0) {
                         this[existingIndex] = field
                     } else {
@@ -161,6 +163,16 @@ class EditTagsProcessor(
 
     private fun parseLyricsOffset(input: String): Int {
         return input.trim().toIntOrNull() ?: 0
+    }
+
+    private fun normalizeCustomTagKey(input: String): String? {
+        val key = input.trim()
+        return when {
+            key.isBlank() -> null
+            key.length > 64 -> null
+            key.any { it == '\n' || it == '\r' } -> null
+            else -> key.uppercase(Locale.ROOT)
+        }
     }
 
     private companion object {

--- a/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
@@ -48,7 +48,8 @@ data class EditTagsTaskConfig(
 @Serializable
 data class EditTagsCustomField(
     val key: String = "",
-    val value: String = ""
+    val value: String? = "",
+    val clear: Boolean = false,
 )
 
 class EditTagsProcessor(
@@ -147,12 +148,9 @@ class EditTagsProcessor(
             tag = tag.copy(customFields = tag.customFields.toMutableList().apply {
                 config.customFields.forEach { newField ->
                     val key = normalizeCustomTagKey(newField.key) ?: return@forEach
-                    val field = CustomTagField(key, newField.value)
-                    val existingIndex = indexOfFirst { it.key.equals(field.key, ignoreCase = true) }
-                    if (existingIndex >= 0) {
-                        this[existingIndex] = field
-                    } else {
-                        add(field)
+                    removeAll { it.key.equals(key, ignoreCase = true) }
+                    if (!newField.clear) {
+                        add(CustomTagField(key, newField.value.orEmpty()))
                     }
                 }
             })

--- a/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/EditTagsProcessor.kt
@@ -48,8 +48,7 @@ data class EditTagsTaskConfig(
 @Serializable
 data class EditTagsCustomField(
     val key: String = "",
-    val value: String? = "",
-    val clear: Boolean = false,
+    val value: String = "",
 )
 
 class EditTagsProcessor(
@@ -149,9 +148,7 @@ class EditTagsProcessor(
                 config.customFields.forEach { newField ->
                     val key = normalizeCustomTagKey(newField.key) ?: return@forEach
                     removeAll { it.key.equals(key, ignoreCase = true) }
-                    if (!newField.clear) {
-                        add(CustomTagField(key, newField.value.orEmpty()))
-                    }
+                    add(CustomTagField(key, newField.value))
                 }
             })
         }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/MatchMetadataProcessor.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/worker/processor/MatchMetadataProcessor.kt
@@ -284,6 +284,8 @@ class MatchMetadataProcessor(
         if (!success) {
             throw Exception("Write failed")
         }
+        val savedTagData = songRepository.readAudioTagData(song.uri)
+        songRepository.updateSongMetadata(savedTagData, song.uri, System.currentTimeMillis())
         onProgress(1f)
 
         return BatchTaskProcessResult()

--- a/lyrico-app/src/main/res/values-zh-rCN/strings.xml
+++ b/lyrico-app/src/main/res/values-zh-rCN/strings.xml
@@ -494,10 +494,6 @@
     <string name="custom_tag_song_count">%1$d 首歌曲</string>
     <string name="custom_tag_delete_current_value">删除当前歌曲中的标签值</string>
     <string name="custom_tag_delete_current_value_summary">这只会删除当前歌曲中的该标签，不会从编辑页显示列表中移除。</string>
-    <string name="batch_custom_tag_keep">不修改</string>
-    <string name="batch_custom_tag_set">设置值</string>
-    <string name="batch_custom_tag_clear">清除标签</string>
-    <string name="batch_custom_tag_clear_summary">保存后会从所有选中歌曲中删除这个自定义标签。</string>
 
     <!-- 批量编辑 -->
     <string name="batch_edit_title">编辑标签</string>

--- a/lyrico-app/src/main/res/values-zh-rCN/strings.xml
+++ b/lyrico-app/src/main/res/values-zh-rCN/strings.xml
@@ -476,6 +476,24 @@
     <string name="action_add_custom_tag">添加自定义标签</string>
     <string name="action_remove_custom_tag">移除标签</string>
     <string name="custom_tags_empty">还没有自定义标签，点击“添加标签”即可创建。</string>
+    <string name="custom_tag_management_title">自定义标签管理</string>
+    <string name="custom_tag_visible_section">编辑页显示标签</string>
+    <string name="custom_tag_visible_summary">添加到这里的自定义标签会显示在歌曲编辑页面。</string>
+    <string name="custom_tag_discovered_section">所有已发现标签</string>
+    <string name="custom_tag_discovered_summary">这些标签来自当前音乐库，可添加到编辑页显示。</string>
+    <string name="custom_tag_add_key">添加自定义标签键</string>
+    <string name="custom_tag_key">标签键名</string>
+    <string name="custom_tag_key_hint">请输入音频标签中的自定义字段 key，例如 SOURCE、MOOD、CATALOG_NO。</string>
+    <string name="custom_tag_add_to_visible">添加到显示</string>
+    <string name="custom_tag_remove_visible">移除显示</string>
+    <string name="custom_tag_already_visible">已显示</string>
+    <string name="custom_tag_empty_visible_title">尚未添加显示标签</string>
+    <string name="custom_tag_empty_visible_summary">添加标签键后，它会显示在歌曲编辑页面。</string>
+    <string name="custom_tag_remove_notice">移除显示不会删除歌曲中的已有数据。</string>
+    <string name="custom_tag_search_hint">搜索标签 key</string>
+    <string name="custom_tag_song_count">%1$d 首歌曲</string>
+    <string name="custom_tag_delete_current_value">删除当前歌曲中的标签值</string>
+    <string name="custom_tag_delete_current_value_summary">这只会删除当前歌曲中的该标签，不会从编辑页显示列表中移除。</string>
 
     <!-- 批量编辑 -->
     <string name="batch_edit_title">编辑标签</string>

--- a/lyrico-app/src/main/res/values-zh-rCN/strings.xml
+++ b/lyrico-app/src/main/res/values-zh-rCN/strings.xml
@@ -478,9 +478,9 @@
     <string name="custom_tags_empty">还没有自定义标签，点击“添加标签”即可创建。</string>
     <string name="custom_tag_management_title">自定义标签管理</string>
     <string name="custom_tag_visible_section">编辑页显示标签</string>
-    <string name="custom_tag_visible_summary">添加到这里的自定义标签会显示在歌曲编辑页面。</string>
+    <string name="custom_tag_visible_summary">添加到这里的自定义标签会显示在单曲编辑页和批量编辑页。</string>
     <string name="custom_tag_discovered_section">所有已发现标签</string>
-    <string name="custom_tag_discovered_summary">这些标签来自当前音乐库，可添加到编辑页显示。</string>
+    <string name="custom_tag_discovered_summary">这些标签来自当前音乐库，可添加到编辑页和批量编辑页显示。</string>
     <string name="custom_tag_add_key">添加自定义标签键</string>
     <string name="custom_tag_key">标签键名</string>
     <string name="custom_tag_key_hint">请输入音频标签中的自定义字段 key，例如 SOURCE、MOOD、CATALOG_NO。</string>
@@ -488,12 +488,16 @@
     <string name="custom_tag_remove_visible">移除显示</string>
     <string name="custom_tag_already_visible">已显示</string>
     <string name="custom_tag_empty_visible_title">尚未添加显示标签</string>
-    <string name="custom_tag_empty_visible_summary">添加标签键后，它会显示在歌曲编辑页面。</string>
+    <string name="custom_tag_empty_visible_summary">添加标签键后，它会显示在单曲编辑页和批量编辑页。</string>
     <string name="custom_tag_remove_notice">移除显示不会删除歌曲中的已有数据。</string>
     <string name="custom_tag_search_hint">搜索标签 key</string>
     <string name="custom_tag_song_count">%1$d 首歌曲</string>
     <string name="custom_tag_delete_current_value">删除当前歌曲中的标签值</string>
     <string name="custom_tag_delete_current_value_summary">这只会删除当前歌曲中的该标签，不会从编辑页显示列表中移除。</string>
+    <string name="batch_custom_tag_keep">不修改</string>
+    <string name="batch_custom_tag_set">设置值</string>
+    <string name="batch_custom_tag_clear">清除标签</string>
+    <string name="batch_custom_tag_clear_summary">保存后会从所有选中歌曲中删除这个自定义标签。</string>
 
     <!-- 批量编辑 -->
     <string name="batch_edit_title">编辑标签</string>

--- a/lyrico-app/src/main/res/values/strings.xml
+++ b/lyrico-app/src/main/res/values/strings.xml
@@ -359,9 +359,9 @@
     <string name="custom_tags_empty">No custom tags yet. Tap \"Add Tag\" to create one.</string>
     <string name="custom_tag_management_title">Custom tag management</string>
     <string name="custom_tag_visible_section">Tags shown in editor</string>
-    <string name="custom_tag_visible_summary">Custom tags added here will be shown on the song edit page.</string>
+    <string name="custom_tag_visible_summary">Custom tags added here will be shown on the song edit page and batch edit page.</string>
     <string name="custom_tag_discovered_section">All discovered tags</string>
-    <string name="custom_tag_discovered_summary">These tags were found in the current music library and can be added to the editor.</string>
+    <string name="custom_tag_discovered_summary">These tags were found in the current music library and can be added to the editor and batch editor.</string>
     <string name="custom_tag_add_key">Add custom tag key</string>
     <string name="custom_tag_key">Tag key</string>
     <string name="custom_tag_key_hint">Enter a custom audio tag key, for example SOURCE, MOOD, or CATALOG_NO.</string>
@@ -369,12 +369,16 @@
     <string name="custom_tag_remove_visible">Remove from editor</string>
     <string name="custom_tag_already_visible">Shown</string>
     <string name="custom_tag_empty_visible_title">No custom tags added</string>
-    <string name="custom_tag_empty_visible_summary">After adding a tag key, it will be shown on the song edit page.</string>
+    <string name="custom_tag_empty_visible_summary">After adding a tag key, it will be shown on the song edit page and batch edit page.</string>
     <string name="custom_tag_remove_notice">Removing a tag from the editor does not delete existing song data.</string>
     <string name="custom_tag_search_hint">Search tag key</string>
     <string name="custom_tag_song_count">%1$d songs</string>
     <string name="custom_tag_delete_current_value">Delete value from current song</string>
     <string name="custom_tag_delete_current_value_summary">This only deletes the tag from the current song. It does not remove the tag from the editor display list.</string>
+    <string name="batch_custom_tag_keep">Keep</string>
+    <string name="batch_custom_tag_set">Set value</string>
+    <string name="batch_custom_tag_clear">Clear tag</string>
+    <string name="batch_custom_tag_clear_summary">Saving will delete this custom tag from all selected songs.</string>
     <string name="label_file_size">File Size</string>
     <!-- Cover Editor -->
     <string name="status_modified">Modified</string>

--- a/lyrico-app/src/main/res/values/strings.xml
+++ b/lyrico-app/src/main/res/values/strings.xml
@@ -357,6 +357,24 @@
     <string name="action_add_custom_tag">Add Custom Tag</string>
     <string name="action_remove_custom_tag">Remove Tag</string>
     <string name="custom_tags_empty">No custom tags yet. Tap \"Add Tag\" to create one.</string>
+    <string name="custom_tag_management_title">Custom tag management</string>
+    <string name="custom_tag_visible_section">Tags shown in editor</string>
+    <string name="custom_tag_visible_summary">Custom tags added here will be shown on the song edit page.</string>
+    <string name="custom_tag_discovered_section">All discovered tags</string>
+    <string name="custom_tag_discovered_summary">These tags were found in the current music library and can be added to the editor.</string>
+    <string name="custom_tag_add_key">Add custom tag key</string>
+    <string name="custom_tag_key">Tag key</string>
+    <string name="custom_tag_key_hint">Enter a custom audio tag key, for example SOURCE, MOOD, or CATALOG_NO.</string>
+    <string name="custom_tag_add_to_visible">Show in editor</string>
+    <string name="custom_tag_remove_visible">Remove from editor</string>
+    <string name="custom_tag_already_visible">Shown</string>
+    <string name="custom_tag_empty_visible_title">No custom tags added</string>
+    <string name="custom_tag_empty_visible_summary">After adding a tag key, it will be shown on the song edit page.</string>
+    <string name="custom_tag_remove_notice">Removing a tag from the editor does not delete existing song data.</string>
+    <string name="custom_tag_search_hint">Search tag key</string>
+    <string name="custom_tag_song_count">%1$d songs</string>
+    <string name="custom_tag_delete_current_value">Delete value from current song</string>
+    <string name="custom_tag_delete_current_value_summary">This only deletes the tag from the current song. It does not remove the tag from the editor display list.</string>
     <string name="label_file_size">File Size</string>
     <!-- Cover Editor -->
     <string name="status_modified">Modified</string>

--- a/lyrico-app/src/main/res/values/strings.xml
+++ b/lyrico-app/src/main/res/values/strings.xml
@@ -375,10 +375,6 @@
     <string name="custom_tag_song_count">%1$d songs</string>
     <string name="custom_tag_delete_current_value">Delete value from current song</string>
     <string name="custom_tag_delete_current_value_summary">This only deletes the tag from the current song. It does not remove the tag from the editor display list.</string>
-    <string name="batch_custom_tag_keep">Keep</string>
-    <string name="batch_custom_tag_set">Set value</string>
-    <string name="batch_custom_tag_clear">Clear tag</string>
-    <string name="batch_custom_tag_clear_summary">Saving will delete this custom tag from all selected songs.</string>
     <string name="label_file_size">File Size</string>
     <!-- Cover Editor -->
     <string name="status_modified">Modified</string>


### PR DESCRIPTION
- 添加自定义标签数据库表和迁移脚本
- 实现自定义标签键值仓库管理
- 创建自定义标签管理视图模型和界面
- 集成自定义标签到元数据编辑界面
- 移除批量编辑中的自定义标签相关代码
- 更新依赖注入配置以支持新功能
- 添加自定义标签设置选项到设置页面
- 实现自定义标签的可见性管理逻辑