### PR TITLE
feat: 本地搜索页面添加结果分类 Tab 切换

### DIFF
--- a/lyrico-app/src/main/java/com/lonx/lyrico/data/model/search/LocalSearchResultTab.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/data/model/search/LocalSearchResultTab.kt
@@ -1,0 +1,13 @@
+package com.lonx.lyrico.data.model.search
+
+import com.lonx.lyrico.R
+
+/**
+ * 本地搜索结果分类标签
+ * 对应结果类型：单曲/专辑/艺术家
+ */
+enum class LocalSearchResultTab(val labelRes: Int) {
+    SONGS(R.string.search_section_songs),
+    ALBUMS(R.string.search_section_albums),
+    ARTISTS(R.string.search_section_artists)
+}

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -119,58 +120,68 @@ fun LocalSearchScreen(
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             topBar = {
-                Column(
-                    modifier = Modifier.background(MiuixTheme.colorScheme.surface)
-                ) {
-                    AnimatedContent(
-                        targetState = isSelectionMode,
-                        label = "LocalSearchTopBarAnimation",
-                        transitionSpec = {
-                            val animationDuration = 300
-                            val enter = fadeIn(tween(animationDuration)) +
-                                slideInVertically(
-                                    animationSpec = tween(
-                                        animationDuration,
-                                        easing = FastOutSlowInEasing
-                                    ),
-                                    initialOffsetY = { -it / 3 }
-                                )
-                            val exit = fadeOut(tween(animationDuration)) +
-                                slideOutVertically(
-                                    animationSpec = tween(
-                                        animationDuration,
-                                        easing = FastOutSlowInEasing
-                                    ),
-                                    targetOffsetY = { -it / 3 }
-                                )
+                AnimatedContent(
+                    targetState = isSelectionMode,
+                    label = "LocalSearchTopBarAnimation",
+                    transitionSpec = {
+                        val animationDuration = 300
+                        val enter = fadeIn(tween(animationDuration)) +
+                            slideInVertically(
+                                animationSpec = tween(
+                                    animationDuration,
+                                    easing = FastOutSlowInEasing
+                                ),
+                                initialOffsetY = { -it / 3 }
+                            )
+                        val exit = fadeOut(tween(animationDuration)) +
+                            slideOutVertically(
+                                animationSpec = tween(
+                                    animationDuration,
+                                    easing = FastOutSlowInEasing
+                                ),
+                                targetOffsetY = { -it / 3 }
+                            )
 
-                            (enter togetherWith exit).using(SizeTransform(clip = false))
-                        }
-                    ) { selectionMode ->
-                        if (selectionMode) {
-                            SongSelectionTopAppBar(
-                                songs = uiState.songs,
-                                selectedSongUris = selectedSongUris,
-                                scrollBehavior = topAppBarScrollBehavior,
-                                onSelectAll = selectionViewModel::selectAll,
-                                onDeselectAll = selectionViewModel::deselectAll,
-                                onClose = selectionViewModel::exitSelectionMode
-                            )
-                        } else {
-                            SmallTopAppBar(
-                                title = stringResource(R.string.local_search_title),
-                                navigationIcon = {
-                                    IconButton(onClick = { navigator.popBackStack() }) {
-                                        Icon(
-                                            imageVector = MiuixIcons.Back,
-                                            contentDescription = stringResource(R.string.action_back)
-                                        )
-                                    }
-                                },
-                                scrollBehavior = topAppBarScrollBehavior
-                            )
-                        }
+                        (enter togetherWith exit).using(SizeTransform(clip = false))
+                    },
+                    modifier = Modifier
+                        .background(MiuixTheme.colorScheme.surface)
+                        .fillMaxWidth()
+                ) { selectionMode ->
+                    if (selectionMode) {
+                        SongSelectionTopAppBar(
+                            songs = uiState.songs,
+                            selectedSongUris = selectedSongUris,
+                            scrollBehavior = topAppBarScrollBehavior,
+                            onSelectAll = selectionViewModel::selectAll,
+                            onDeselectAll = selectionViewModel::deselectAll,
+                            onClose = selectionViewModel::exitSelectionMode
+                        )
+                    } else {
+                        SmallTopAppBar(
+                            title = stringResource(R.string.local_search_title),
+                            navigationIcon = {
+                                IconButton(onClick = { navigator.popBackStack() }) {
+                                    Icon(
+                                        imageVector = MiuixIcons.Back,
+                                        contentDescription = stringResource(R.string.action_back)
+                                    )
+                                }
+                            },
+                            scrollBehavior = topAppBarScrollBehavior
+                        )
                     }
+                }
+            }
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(scaffoldContentPadding(paddingValues))
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize()
+                ) {
                     AnimatedVisibility(
                         visible = !isSelectionMode,
                         enter = expandVertically(
@@ -209,145 +220,165 @@ fun LocalSearchScreen(
                                 .padding(horizontal = 12.dp, vertical = 8.dp)
                         )
                     }
-                    if (searchQuery.isNotBlank()) {
-                        LocalSearchTypeTabs(
-                            selectedTab = currentTab,
-                            onTabSelected = { currentTab = it }
-                        )
-                    }
-                }
-            }
-        ) { paddingValues ->
-            LazyColumn(
-                modifier = Modifier
-                    .scrollEndHaptic()
-                    .overScrollVertical()
-                    .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-                    .dragSelection(
-                        listState = listState,
-                        itemCount = uiState.songs.size,
-                        isSelectionMode = isSelectionMode,
-                        itemInfoMapper = { itemInfo ->
-                            songIndexByLazyListKey[itemInfo.key]
-                        },
-                        onDragSelectionStart = { index ->
-                            selectionViewModel.startDragSelection(index, uiState.songs)
-                        },
-                        onDragSelectionChange = { startIndex, endIndex ->
-                            selectionViewModel.updateDragSelection(
-                                startIndex,
-                                endIndex,
-                                uiState.songs
+
+                    AnimatedVisibility(
+                        visible = searchQuery.isNotBlank(),
+                        enter = expandVertically(
+                            animationSpec = tween(
+                                durationMillis = 300,
+                                easing = FastOutSlowInEasing
                             )
-                        },
-                        onDragSelectionEnd = selectionViewModel::endDragSelection
-                    )
-                    .fillMaxHeight(),
-                state = listState,
-                contentPadding = scaffoldContentPadding(
-                    paddingValues = paddingValues,
-                    bottomExtra = 12.dp
-                ),
-                overscrollEffect = null
-            ) {
-                if (searchQuery.isNotBlank() && !hasCurrentTabResults) {
-                    item {
-                        SearchEmptyCard()
+                        ) + fadeIn(tween(300)),
+                        exit = shrinkVertically(
+                            animationSpec = tween(
+                                durationMillis = 300,
+                                easing = FastOutSlowInEasing
+                            )
+                        ) + fadeOut(tween(300))
+                    ) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp)
+                                .padding(bottom = 8.dp)
+                        ) {
+                            LocalSearchTypeTabs(
+                                selectedTab = currentTab,
+                                onTabSelected = { currentTab = it }
+                            )
+                        }
                     }
-                }
 
-                if (showArtists && uiState.artists.isNotEmpty()) {
-                    item {
-                        SearchSectionHeader(
-                            title = stringResource(R.string.search_section_artists),
-                            subtitle = stringResource(R.string.song_count, uiState.artists.size)
-                        )
-                    }
-                    items(
-                        items = uiState.artists,
-                        key = { artist -> artist.artist }
-                    ) { artist ->
-                        ArtistSongItem(
-                            name = artist.artist,
-                            subtitle = stringResource(
-                                R.string.album_song_count,
-                                artist.albumCount,
-                                artist.songCount
-                            ),
-                            coverUri = artist.coverSongUri,
-                            coverLastModified = artist.coverSongLastModified,
-                            onClick = {
-                                navigator.navigate(ArtistDetailDestination(artistId = artist.id))
+                    LazyColumn(
+                        modifier = Modifier
+                            .weight(1f)
+                            .scrollEndHaptic()
+                            .overScrollVertical()
+                            .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
+                            .dragSelection(
+                                listState = listState,
+                                itemCount = uiState.songs.size,
+                                isSelectionMode = isSelectionMode,
+                                itemInfoMapper = { itemInfo ->
+                                    songIndexByLazyListKey[itemInfo.key]
+                                },
+                                onDragSelectionStart = { index ->
+                                    selectionViewModel.startDragSelection(index, uiState.songs)
+                                },
+                                onDragSelectionChange = { startIndex, endIndex ->
+                                    selectionViewModel.updateDragSelection(
+                                        startIndex,
+                                        endIndex,
+                                        uiState.songs
+                                    )
+                                },
+                                onDragSelectionEnd = selectionViewModel::endDragSelection
+                            )
+                            .fillMaxHeight(),
+                        state = listState,
+                        contentPadding = PaddingValues(bottom = 12.dp),
+                        overscrollEffect = null
+                    ) {
+                        if (searchQuery.isNotBlank() && !hasCurrentTabResults) {
+                            item {
+                                SearchEmptyCard()
                             }
-                        )
-                    }
-                }
+                        }
 
-                if (showAlbums && uiState.albums.isNotEmpty()) {
-                    item {
-                        SearchSectionHeader(
-                            title = stringResource(R.string.search_section_albums),
-                            subtitle = stringResource(R.string.album_count, uiState.albums.size)
-                        )
-                    }
-                    items(
-                        items = uiState.albums,
-                        key = { album -> "${album.album}|${album.albumArtist.orEmpty()}" }
-                    ) { album ->
-                        AlbumSongItem(
-                            title = album.album,
-                            subtitle = listOfNotNull(
-                                album.albumArtist,
-                                stringResource(R.string.song_count, album.songCount)
-                            ).joinToString(" - "),
-                            coverUri = album.coverSongUri,
-                            coverLastModified = album.coverSongLastModified,
-                            onClick = {
-                                navigator.navigate(
-                                    AlbumDetailDestination(albumId = album.id)
+                        if (showArtists && uiState.artists.isNotEmpty()) {
+                            item {
+                                SearchSectionHeader(
+                                    title = stringResource(R.string.search_section_artists),
+                                    subtitle = stringResource(R.string.song_count, uiState.artists.size)
                                 )
                             }
-                        )
-                    }
-                }
-
-                if (showSongs && uiState.songs.isNotEmpty()) {
-                    item {
-                        SearchSectionHeader(
-                            title = stringResource(R.string.search_section_songs),
-                            subtitle = stringResource(R.string.song_count, uiState.songs.size)
-                        )
-                    }
-                    items(
-                        items = uiState.songs,
-                        key = ::localSearchSongKey
-                    ) { song ->
-                        SongListItem(
-                            song = song,
-                            isSelectionMode = isSelectionMode,
-                            isSelected = selectedSongUris.contains(song.uri),
-                            onClick = {
-                                navigator.navigate(EditMetadataDestination(songFileUri = song.uri))
-                            },
-                            onToggleSelection = {
-                                selectionViewModel.toggleSelection(song.uri)
-                            },
-                            trailingContent = {
-                                Box(modifier = Modifier.padding(end = 8.dp)) {
-                                    SongListItemActions(
-                                        isSelectionMode = isSelectionMode,
-                                        isSelected = selectedSongUris.contains(song.uri),
-                                        onToggleSelection = {
-                                            selectionViewModel.toggleSelection(song.uri)
-                                        },
-                                        onShowMenu = {
-                                            selectedSong = song
-                                            showMenuSheet = true
-                                        }
-                                    )
-                                }
+                            items(
+                                items = uiState.artists,
+                                key = { artist -> artist.artist }
+                            ) { artist ->
+                                ArtistSongItem(
+                                    name = artist.artist,
+                                    subtitle = stringResource(
+                                        R.string.album_song_count,
+                                        artist.albumCount,
+                                        artist.songCount
+                                    ),
+                                    coverUri = artist.coverSongUri,
+                                    coverLastModified = artist.coverSongLastModified,
+                                    onClick = {
+                                        navigator.navigate(ArtistDetailDestination(artistId = artist.id))
+                                    }
+                                )
                             }
-                        )
+                        }
+
+                        if (showAlbums && uiState.albums.isNotEmpty()) {
+                            item {
+                                SearchSectionHeader(
+                                    title = stringResource(R.string.search_section_albums),
+                                    subtitle = stringResource(R.string.album_count, uiState.albums.size)
+                                )
+                            }
+                            items(
+                                items = uiState.albums,
+                                key = { album -> "${album.album}|${album.albumArtist.orEmpty()}" }
+                            ) { album ->
+                                AlbumSongItem(
+                                    title = album.album,
+                                    subtitle = listOfNotNull(
+                                        album.albumArtist,
+                                        stringResource(R.string.song_count, album.songCount)
+                                    ).joinToString(" - "),
+                                    coverUri = album.coverSongUri,
+                                    coverLastModified = album.coverSongLastModified,
+                                    onClick = {
+                                        navigator.navigate(
+                                            AlbumDetailDestination(albumId = album.id)
+                                        )
+                                    }
+                                )
+                            }
+                        }
+
+                        if (showSongs && uiState.songs.isNotEmpty()) {
+                            item {
+                                SearchSectionHeader(
+                                    title = stringResource(R.string.search_section_songs),
+                                    subtitle = stringResource(R.string.song_count, uiState.songs.size)
+                                )
+                            }
+                            items(
+                                items = uiState.songs,
+                                key = ::localSearchSongKey
+                            ) { song ->
+                                SongListItem(
+                                    song = song,
+                                    isSelectionMode = isSelectionMode,
+                                    isSelected = selectedSongUris.contains(song.uri),
+                                    onClick = {
+                                        navigator.navigate(EditMetadataDestination(songFileUri = song.uri))
+                                    },
+                                    onToggleSelection = {
+                                        selectionViewModel.toggleSelection(song.uri)
+                                    },
+                                    trailingContent = {
+                                        Box(modifier = Modifier.padding(end = 8.dp)) {
+                                            SongListItemActions(
+                                                isSelectionMode = isSelectionMode,
+                                                isSelected = selectedSongUris.contains(song.uri),
+                                                onToggleSelection = {
+                                                    selectionViewModel.toggleSelection(song.uri)
+                                                },
+                                                onShowMenu = {
+                                                    selectedSong = song
+                                                    showMenuSheet = true
+                                                }
+                                            )
+                                        }
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
@@ -244,7 +244,10 @@ fun LocalSearchScreen(
                         ) {
                             LocalSearchTypeTabs(
                                 selectedTab = currentTab,
-                                onTabSelected = { currentTab = it }
+                                onTabSelected = {
+                                    if (isSelectionMode) selectionViewModel.exitSelectionMode()
+                                    currentTab = it
+                                }
                             )
                         }
                     }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/screens/LocalSearchScreen.kt
@@ -38,12 +38,14 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lonx.lyrico.R
 import com.lonx.lyrico.data.model.entity.SongEntity
+import com.lonx.lyrico.data.model.search.LocalSearchResultTab
 import com.lonx.lyrico.ui.components.bar.SearchBar
 import com.lonx.lyrico.ui.components.bar.SongBatchSelectionActions
 import com.lonx.lyrico.ui.components.bar.SongSelectionTopAppBar
 import com.lonx.lyrico.ui.components.scaffoldContentPadding
 import com.lonx.lyrico.ui.components.search.AlbumSongItem
 import com.lonx.lyrico.ui.components.search.ArtistSongItem
+import com.lonx.lyrico.ui.components.search.LocalSearchTypeTabs
 import com.lonx.lyrico.ui.components.search.SearchSectionHeader
 import com.lonx.lyrico.ui.components.selection.dragSelection
 import com.lonx.lyrico.ui.components.song.SongActionSheets
@@ -80,6 +82,7 @@ fun LocalSearchScreen(
     val selectionViewModel: SongSelectionViewModel = koinViewModel()
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var currentTab by remember { mutableStateOf(LocalSearchResultTab.SONGS) }
     val isSelectionMode by selectionViewModel.isSelectionMode.collectAsStateWithLifecycle()
     val selectedSongUris by selectionViewModel.selectedSongUris.collectAsStateWithLifecycle()
     val topAppBarScrollBehavior = MiuixScrollBehavior()
@@ -91,9 +94,14 @@ fun LocalSearchScreen(
     var showDetailSheet by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
-    val hasResults = uiState.songs.isNotEmpty() ||
-        uiState.albums.isNotEmpty() ||
-        uiState.artists.isNotEmpty()
+    val hasCurrentTabResults = when (currentTab) {
+        LocalSearchResultTab.ARTISTS -> uiState.artists.isNotEmpty()
+        LocalSearchResultTab.ALBUMS -> uiState.albums.isNotEmpty()
+        LocalSearchResultTab.SONGS -> uiState.songs.isNotEmpty()
+    }
+    val showArtists = currentTab == LocalSearchResultTab.ARTISTS
+    val showAlbums = currentTab == LocalSearchResultTab.ALBUMS
+    val showSongs = currentTab == LocalSearchResultTab.SONGS
     val songIndexByLazyListKey = remember(uiState.songs) {
         uiState.songs
             .mapIndexed { index, song -> localSearchSongKey(song) to index }
@@ -201,6 +209,12 @@ fun LocalSearchScreen(
                                 .padding(horizontal = 12.dp, vertical = 8.dp)
                         )
                     }
+                    if (searchQuery.isNotBlank()) {
+                        LocalSearchTypeTabs(
+                            selectedTab = currentTab,
+                            onTabSelected = { currentTab = it }
+                        )
+                    }
                 }
             }
         ) { paddingValues ->
@@ -236,13 +250,13 @@ fun LocalSearchScreen(
                 ),
                 overscrollEffect = null
             ) {
-                if (searchQuery.isNotBlank() && !hasResults) {
+                if (searchQuery.isNotBlank() && !hasCurrentTabResults) {
                     item {
                         SearchEmptyCard()
                     }
                 }
 
-                if (uiState.artists.isNotEmpty()) {
+                if (showArtists && uiState.artists.isNotEmpty()) {
                     item {
                         SearchSectionHeader(
                             title = stringResource(R.string.search_section_artists),
@@ -269,7 +283,7 @@ fun LocalSearchScreen(
                     }
                 }
 
-                if (uiState.albums.isNotEmpty()) {
+                if (showAlbums && uiState.albums.isNotEmpty()) {
                     item {
                         SearchSectionHeader(
                             title = stringResource(R.string.search_section_albums),
@@ -297,7 +311,7 @@ fun LocalSearchScreen(
                     }
                 }
 
-                if (uiState.songs.isNotEmpty()) {
+                if (showSongs && uiState.songs.isNotEmpty()) {
                     item {
                         SearchSectionHeader(
                             title = stringResource(R.string.search_section_songs),

--- a/lyrico-app/src/main/java/com/lonx/lyrico/ui/components/search/LocalSearchTypeTabs.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/ui/components/search/LocalSearchTypeTabs.kt
@@ -15,17 +15,12 @@ fun LocalSearchTypeTabs(
     onTabSelected: (LocalSearchResultTab) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(
-        modifier = modifier
-            .padding(horizontal = 12.dp)
-            .padding(bottom = 12.dp)
-    ) {
-        TabRowWithContour(
-            tabs = LocalSearchResultTab.entries.map { stringResource(it.labelRes) },
-            selectedTabIndex = LocalSearchResultTab.entries.indexOf(selectedTab),
-            onTabSelected = {
-                onTabSelected(LocalSearchResultTab.entries[it])
-            }
-        )
-    }
+    TabRowWithContour(
+        modifier = modifier,
+        tabs = LocalSearchResultTab.entries.map { stringResource(it.labelRes) },
+        selectedTabIndex = LocalSearchResultTab.entries.indexOf(selectedTab),
+        onTabSelected = {
+            onTabSelected(LocalSearchResultTab.entries[it])
+        }
+    )
 }

--- a/lyrico-app/src/main/java/com/lonx/lyrico/ui/components/search/LocalSearchTypeTabs.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/ui/components/search/LocalSearchTypeTabs.kt
@@ -5,14 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.lonx.lyrico.data.model.search.LocalSearchType
+import com.lonx.lyrico.data.model.search.LocalSearchResultTab
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.TabRowWithContour
 
 @Composable
 fun LocalSearchTypeTabs(
-    selectedType: LocalSearchType,
-    onTypeSelected: (LocalSearchType) -> Unit,
+    selectedTab: LocalSearchResultTab,
+    onTabSelected: (LocalSearchResultTab) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -21,10 +21,10 @@ fun LocalSearchTypeTabs(
             .padding(bottom = 12.dp)
     ) {
         TabRowWithContour(
-            tabs = LocalSearchType.entries.map { stringResource(it.labelRes) },
-            selectedTabIndex = LocalSearchType.entries.indexOf(selectedType),
+            tabs = LocalSearchResultTab.entries.map { stringResource(it.labelRes) },
+            selectedTabIndex = LocalSearchResultTab.entries.indexOf(selectedTab),
             onTabSelected = {
-                onTypeSelected(LocalSearchType.entries[it])
+                onTabSelected(LocalSearchResultTab.entries[it])
             }
         )
     }


### PR DESCRIPTION
为本地搜索页面添加结果分类切换功能（音乐/专辑/艺术家）。

- 新增 LocalSearchResultTab 枚举
- Tab 布局与 ArtistDetailScreen 排版风格保持一致
- 按分类过滤搜索结果
<img width="50%" alt="tabs (1)" src="https://github.com/user-attachments/assets/f28339dc-7c1c-4772-89b8-9d24364e5b5d" />
<img width="50%" alt="tabs (2)" src="https://github.com/user-attachments/assets/457090e2-e490-42cd-806a-de016df3b1bb" />
<img width="50%" alt="tabs (3)" src="https://github.com/user-attachments/assets/5dd3d926-5c8f-4b6f-9cf2-b94690527426" />
