### PR TITLE
fix: 主搜索纳入元数据源，仅 searchSongs 能力的插件无法参与搜索

### DIFF
--- a/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/SearchViewModel.kt
+++ b/lyrico-app/src/main/java/com/lonx/lyrico/viewmodel/SearchViewModel.kt
@@ -147,8 +147,14 @@ class SearchViewModel(
                 SharingStarted.WhileSubscribed(5000),
                 null
             )
+    // 改为：聚合源 + 元数据源（去重，聚合在前）
     private val allSourcesFlow =
-        searchSourceProvider.observeSources(PluginSourceType.AGGREGATED).stateIn(
+        combine(
+            searchSourceProvider.observeSources(PluginSourceType.AGGREGATED),
+            searchSourceProvider.observeSources(PluginSourceType.METADATA)
+        ) { aggregated, metadata ->
+            aggregated + metadata.filter { m -> aggregated.none { it.id == m.id } }
+        }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
             emptyList()


### PR DESCRIPTION
## 问题

主搜索（SearchViewModel）只调度 PluginSourceType.AGGREGATED（三能力齐备）的插件， 但搜索动作本身只调用 searchSongs，不依赖 getLyrics；歌词是选歌后的可选路径，
无歌词时已有优雅降级（「歌词为空」状态，写标签对话框中 lyrics 为可选字段）。

结果：仅具备元数据能力（searchSongs）的插件（如 MusicBrainz）只能用于批量匹配， 在交互式搜索中无处可用。

## 改动

SearchViewModel 源列表改为「聚合源 + 元数据源（去重）」，聚合源在前。
插件管理「元数据源」开关语义扩展为：控制该源在主搜索与批量匹配中的参与。

## 测试

- 仅 searchSongs+searchCovers 的插件：主搜索可搜、可打标，歌词显示「歌词为空」
- 三能力插件：行为不变，列表中不重复